### PR TITLE
Support opening auxiliary views

### DIFF
--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -39,6 +39,7 @@ type TrackDataStore = Map<string, {}>;
 type QueryResultsStore = Map<string, {}|undefined>;
 type AggregateDataStore = Map<string, AggregateData>;
 type Description = Map<string, string>;
+type ViewOpener = (url: string) => void;
 
 export interface SliceDetails {
   ts?: number;
@@ -250,6 +251,8 @@ class Globals {
   private _disableMainRendering?: boolean = undefined;
   private _disableHashBasedRouting?: boolean = undefined;
   private _cachePrefix: string = '';
+
+  private _viewOpener?: ViewOpener = undefined;
 
   // Init from session storage since correct value may be required very early on
   private _relaxContentSecurity: boolean = window.sessionStorage.getItem(RELAX_CONTENT_SECURITY) === 'true';
@@ -619,6 +622,14 @@ class Globals {
 
   set ftracePanelData(data: FtracePanelData|undefined) {
     this._ftracePanelData = data;
+  }
+
+  get viewOpener(): ViewOpener | undefined {
+    return this._viewOpener;
+  }
+
+  set viewOpener(viewOpener: ViewOpener | undefined) {
+    this._viewOpener = viewOpener;
   }
 
   makeSelection(action: DeferredAction<{}>, tabToOpen = 'current_selection') {

--- a/ui/src/frontend/topbar.ts
+++ b/ui/src/frontend/topbar.ts
@@ -242,14 +242,18 @@ class TraceErrorIcon implements m.ClassComponent {
     if (!errors && !globals.metricError || mode === COMMAND) return;
     const message = errors ? `${errors} import or data loss errors detected.` :
                              `Metric error detected.`;
-    return m(
-        'a.error',
-        {href: '#!/info'},
-        m('i.material-icons',
-          {
-            title: message + ` Click for more info.`,
-          },
-          'announcement'));
+    const icon = m(
+      'i.material-icons',
+      {
+        title: message + ` Click for more info.`
+      },
+      'announcement');
+
+    if (globals.viewOpener) {
+      const viewOpener = globals.viewOpener;
+      return m('button.error', {onclick: () => viewOpener('#!/info')}, icon);
+    }
+    return m('a.error', {href: '#!/info'}, icon);
   }
 }
 


### PR DESCRIPTION
_**Note** that this PR is in support of eclipsesource/project-enola#56._

Add a "view opener" function to the globals that allows injection of a mechanism to open an auxiliary page in a separate Theia view.

Employ this view opener in the Errors (info) button in the topbar.


