### PR TITLE
Suppress file dropping and non-errors

### DIFF
--- a/ui/src/common/http_rpc_engine.ts
+++ b/ui/src/common/http_rpc_engine.ts
@@ -29,9 +29,13 @@ export interface HttpRpcState {
   failure?: string;
 }
 
+/** A call-back to customize a newly created HTTP+RPC engine. */
+export type HttpRcpEngineCustomizer = (engine: HttpRpcEngine) => unknown;
+
 export class HttpRpcEngine extends Engine {
   readonly id: string;
   errorHandler: (err: string) => void = () => {};
+  closeHandler: (code: number, reason: string) => void = (code, reason) => this.errorHandler(`Websocket closed (${code}: ${reason})`);
   private requestQueue = new Array<Uint8Array>();
   private websocket?: WebSocket;
   private connected = false;
@@ -47,7 +51,7 @@ export class HttpRpcEngine extends Engine {
       this.websocket.onopen = () => this.onWebsocketConnected();
       this.websocket.onmessage = (e) => this.onWebsocketMessage(e);
       this.websocket.onclose = (e) =>
-          this.errorHandler(`Websocket closed (${e.code}: ${e.reason})`);
+          this.closeHandler(e.code, e.reason);
       this.websocket.onerror = (e) =>
           this.errorHandler(`WebSocket error: ${e}`);
     }

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -342,6 +342,7 @@ export class TraceController extends Controller<States> {
             Actions.setEngineFailed({mode: 'HTTP_RPC', failure: `${err}`}));
         throw err;
       };
+      globals.httpRpcEngineCustomizer?.(engine);
     } else {
       console.log('Opening trace using built-in WASM engine');
       engineMode = 'WASM';

--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { HttpRcpEngineCustomizer } from '../common/http_rpc_engine';
 import { assertExists } from '../base/logging';
 import { Actions, DeferredAction } from '../common/actions';
 import { AggregateData } from '../common/aggregation_data';
@@ -253,6 +254,8 @@ class Globals {
   private _cachePrefix: string = '';
 
   private _viewOpener?: ViewOpener = undefined;
+  private _allowFileDrop = true;
+  private _httpRpcEngineCustomizer?: HttpRcpEngineCustomizer;
 
   // Init from session storage since correct value may be required very early on
   private _relaxContentSecurity: boolean = window.sessionStorage.getItem(RELAX_CONTENT_SECURITY) === 'true';
@@ -630,6 +633,22 @@ class Globals {
 
   set viewOpener(viewOpener: ViewOpener | undefined) {
     this._viewOpener = viewOpener;
+  }
+
+  get allowFileDrop(): boolean {
+    return this._allowFileDrop;
+  }
+
+  set allowFileDrop(allowFileDrop: boolean) {
+    this._allowFileDrop = allowFileDrop;
+  }
+
+  get httpRpcEngineCustomizer(): HttpRcpEngineCustomizer | undefined {
+    return this._httpRpcEngineCustomizer;
+  }
+
+  set httpRpcEngineCustomizer(httpRpcEngineCustomizer: HttpRcpEngineCustomizer | undefined) {
+    this._httpRpcEngineCustomizer = httpRpcEngineCustomizer;
   }
 
   makeSelection(action: DeferredAction<{}>, tabToOpen = 'current_selection') {

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -355,7 +355,7 @@ function onCssLoaded() {
   // accidentially clober the state of an open trace processor instance
   // otherwise.
   CheckHttpRpcConnection().then(() => {
-    if (!globals.embeddedMode) {
+    if (!globals.embeddedMode && globals.allowFileDrop) {
       installFileDropHandler();
     }
 


### PR DESCRIPTION
_**Note** that this PR is in support of eclipsesource/project-enola#61 and must be merged before that._

- implement a mechanism to suppress the built-in handling of trace file drop
- do not re-throw the error reported on close of the HTTP RPC websocket
