### PR TITLE
Track filtering API

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -674,6 +674,19 @@ button.query-ctrl {
     border-top: 1px solid var(--main-foreground-color);
     margin-top: -1px;
   }
+  .track-button {
+    color: rgb(60, 86, 136);
+    &.action {
+      @include transition();
+      cursor: pointer;
+      width: 22px;
+      font-size: 18px;
+      opacity: 0;
+    }
+  }
+  &:hover .track-button.action {
+    opacity: 1;
+  }
   &[collapsed="true"] {
     .shell {
       border-right: 1px solid var(--main-foreground-color);
@@ -689,9 +702,6 @@ button.query-ctrl {
     font-weight: bold;
     .shell.flash {
       color: #121212;
-    }
-    .track-button {
-      color: white;
     }
     span.chip {
       color: #121212;

--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Draft} from 'immer';
+import {current, Draft} from 'immer';
 
 import {assertExists, assertTrue, assertUnreachable} from '../base/logging';
 import {RecordConfig} from '../controller/record_config_types';
@@ -57,12 +57,14 @@ import {
   Status,
   ThreadTrackSortKey,
   TraceTime,
+  TrackGroupState,
   TrackSortKey,
   TrackState,
   UtidToTrackSortKey,
   VisibleState,
 } from './state';
 import {TPDuration, TPTime} from './time';
+import { STR } from './query_result';
 
 export const DEBUG_SLICE_TRACK_KIND = 'DebugSliceTrack';
 
@@ -76,7 +78,6 @@ export interface AddTrackArgs {
   labels?: string[];
   trackSortKey: TrackSortKey;
   trackGroup?: string;
-  isUserDefined?: boolean;
   config: {};
 }
 
@@ -142,8 +143,6 @@ function generateNextId(draft: StateDraft): string {
 }
 
 // A helper to clean the state for a given removeable track.
-// This is not exported as action to make it clear that not all
-// tracks are removeable.
 function removeTrack(state: StateDraft, trackId: string) {
   const track = state.tracks[trackId];
   delete state.tracks[trackId];
@@ -159,6 +158,88 @@ function removeTrack(state: StateDraft, trackId: string) {
     removeTrackId(state.trackGroups[track.trackGroup].tracks);
   }
   state.pinnedTracks = state.pinnedTracks.filter((id) => id !== trackId);
+}
+
+// A helper to clean the state for a given removable track group.
+function removeTrackGroup(state: StateDraft, groupId: string) {
+  delete state.trackGroups[groupId];
+
+  state.pinnedTracks = state.pinnedTracks.filter((id) => id !== groupId);
+}
+
+function hasRemovable<T extends AddTrackLikeArgs>(item: T): item is T & {isRemovable: boolean} {
+  return 'isRemovable' in item && typeof item.isRemovable === 'boolean';
+}
+
+function wasFiltered<T extends TrackState|TrackGroupState>(item: T): item is T & {wasFiltered?: true} {
+  return 'wasFiltered' in item && item.wasFiltered === true;
+}
+
+function isFilteredTrack(track: Partial<AddTrackArgs>): boolean {
+  return globals.trackFilteringEnabled && globals.filteredTracks
+      .some(filtered => isAddTrackArgs(filtered) && isSameTrack(filtered, track));
+}
+
+// Query whether an |other| track matches enough details of a |track| as
+// to represent the same track
+function isSameTrack(track: AddTrackArgs, other: Partial<AddTrackArgs>): boolean {
+  return track.kind === other.kind
+      && track.trackGroup == other.trackGroup
+      // TODO: This may not be reliable. May need to deep-compare the config object
+      && track.name == other.name;
+}
+
+function isFilteredTrackGroup(trackGroup: Partial<AddTrackGroupArgs>): boolean {
+  return globals.trackFilteringEnabled && globals.filteredTracks
+    .some(filtered => isAddTrackGroupArgs(filtered) && filtered.id === trackGroup.id);
+}
+
+function unfilterTracklike(predicate: (tracklike: AddTrackLikeArgs) => boolean) {
+  const index = globals.filteredTracks.findIndex(predicate);
+  if (index >= 0) {
+    globals.filteredTracks.splice(index, 1);
+  }
+}
+
+function unfilterTrack(track: TrackState) {
+  track.isRemovable = true;
+  (track as any).wasFiltered = true;
+  unfilterTracklike(filtered => isAddTrackArgs(filtered) && isSameTrack(filtered, track));
+}
+
+function unfilterTrackGroup(trackGroup: TrackGroupState) {
+  trackGroup.isRemovable = true;
+  (trackGroup as any).wasFiltered = true;
+  unfilterTracklike(filtered => isAddTrackGroupArgs(filtered) && filtered.id === trackGroup.id);
+}
+
+// A helper to delete the private tables and views created by a track.
+// TODO: These should recorded by each track that creates them and cleaned up
+//       by an explicit disposable-track protocol.
+async function dropTables(engineId: string, trackId: string) {
+  const engine = assertExists(globals.engines.get(engineId));
+  const suffix = trackId.split('-').join('_');
+  const result = await engine.query(`
+      select name, type from sqlite_schema
+      where name like '%_${suffix}'
+      union select name, type from sqlite_temp_schema
+      where name like '%_${suffix}'`);
+
+  const it = result.iter({name: STR, type: STR});
+  const dropStmts: string[] = [];
+  for (; it.valid(); it.next()) {
+    dropStmts.push(`drop ${it.type} ${it.name};`);
+  }
+
+  for (const stmt of dropStmts) {
+    try {
+      await engine.query(stmt);
+    } catch (_error) {
+      // This is expected, depending on the order in which
+      // we attempt to drop things (some may already be
+      // implicitly dropped)
+    }
+  }
 }
 
 let statusTraceEvent: TraceEventScope|undefined;
@@ -219,11 +300,28 @@ export const StateActions = {
     state.traceUuid = args.traceUuid;
   },
 
-  fillUiTrackIdByTraceTrackId(
-      state: StateDraft, trackState: TrackState, uiTrackId: string) {
+  updateUiTrackIdByTraceTrackId(
+      trackState: TrackState, uiTrackId: string,
+      updater: (trackId: number, uiTrackId: string) => void) {
     const namespace = (trackState.config as {namespace?: string}).namespace;
     if (namespace !== undefined) return;
 
+    const config = trackState.config as {trackId: number};
+    if (config.trackId !== undefined) {
+      updater(config.trackId, uiTrackId);
+      return;
+    }
+
+    const multiple = trackState.config as {trackIds: number[]};
+    if (multiple.trackIds !== undefined) {
+      for (const trackId of multiple.trackIds) {
+        updater(trackId, uiTrackId);
+      }
+    }
+  },
+
+  fillUiTrackIdByTraceTrackId(
+      state: StateDraft, trackState: TrackState, uiTrackId: string) {
     const setUiTrackId = (trackId: number, uiTrackId: string) => {
       if (state.uiTrackIdByTraceTrackId[trackId] !== undefined &&
           state.uiTrackIdByTraceTrackId[trackId] !== uiTrackId) {
@@ -234,18 +332,18 @@ export const StateActions = {
       state.uiTrackIdByTraceTrackId[trackId] = uiTrackId;
     };
 
-    const config = trackState.config as {trackId: number};
-    if (config.trackId !== undefined) {
-      setUiTrackId(config.trackId, uiTrackId);
-      return;
-    }
+    this.updateUiTrackIdByTraceTrackId(trackState, uiTrackId, setUiTrackId);
+  },
 
-    const multiple = trackState.config as {trackIds: number[]};
-    if (multiple.trackIds !== undefined) {
-      for (const trackId of multiple.trackIds) {
-        setUiTrackId(trackId, uiTrackId);
+  cleanUiTrackIdByTraceTrackId(
+      state: StateDraft, trackState: TrackState, uiTrackId: string) {
+    const cleanUiTrackId = (trackId: number, uiTrackId: string) => {
+      if (state.uiTrackIdByTraceTrackId[trackId] === uiTrackId) {
+            delete state.uiTrackIdByTraceTrackId[trackId];
       }
-    }
+    };
+
+    this.updateUiTrackIdByTraceTrackId(trackState, uiTrackId, cleanUiTrackId);
   },
 
   addTracks(state: StateDraft, args: {tracks: AddTrackArgs[]}) {
@@ -270,7 +368,6 @@ export const StateActions = {
   addTrack(state: StateDraft, args: {
     id?: string; engineId: string; kind: string; name: string;
     trackGroup?: string; config: {}; trackSortKey: TrackSortKey;
-    isUserDefined?: boolean;
   }): void {
     const id = args.id !== undefined ? args.id : generateNextId(state);
     state.tracks[id] = {
@@ -282,9 +379,15 @@ export const StateActions = {
       trackGroup: args.trackGroup,
       config: args.config,
     };
-    if (args.isUserDefined !== undefined) {
-      state.tracks[id].isUserDefined = args.isUserDefined;
+
+    // A track group is removable if that was explicitly requested
+    // or if it is currently filtered out of view
+    if (hasRemovable(args)) {
+      state.tracks[id].isRemovable = args.isRemovable;
+    } else if (isFilteredTrack(args)) {
+      unfilterTrack(state.tracks[id]);
     }
+
     this.fillUiTrackIdByTraceTrackId(state, state.tracks[id], id);
     if (args.trackGroup === SCROLLING_TRACK_GROUP) {
       state.scrollingTracks.push(id);
@@ -297,7 +400,10 @@ export const StateActions = {
       state: StateDraft,
       // Define ID in action so a track group can be referred to without running
       // the reducer.
-      args: AddTrackGroupArgs): void {
+      args: {
+        engineId: string; name: string; id: string; summaryTrackId: string;
+        collapsed: boolean;
+      }): void {
     state.trackGroups[args.id] = {
       engineId: args.engineId,
       name: args.name,
@@ -305,6 +411,14 @@ export const StateActions = {
       collapsed: args.collapsed,
       tracks: [args.summaryTrackId],
     };
+
+    // A track group is removable if that was explicitly requested
+    // or if it is currently filtered out of view
+    if (hasRemovable(args)) {
+      state.trackGroups[args.id].isRemovable = args.isRemovable;
+    } else if (isFilteredTrackGroup(args)) {
+      unfilterTrackGroup(state.trackGroups[args.id]);
+    }
   },
 
   addTrackLike(state: StateDraft, args: AddTrackLikeArgs): void {
@@ -341,10 +455,60 @@ export const StateActions = {
     removeTrack(state, args.trackId);
   },
 
-  removeUserDefinedTrack(state: StateDraft, args: {trackId: string}): void {
+  // Remove a track if it is removable as indicated by the
+  // |isRemovable| property of its state.
+  removeTrack(state: StateDraft, args: {trackId: string}): void {
     const track = state.tracks[args.trackId];
-    assertTrue(track.isUserDefined ?? false);
+    assertTrue(track.isRemovable ?? false);
     removeTrack(state, args.trackId);
+
+    this.cleanUiTrackIdByTraceTrackId(state, track as TrackState, args.trackId);
+
+    if (wasFiltered(track)) {
+      delete track.wasFiltered;
+
+      // Don't assume that we can reuse the track's ID, unless
+      // it's a group summary track that has a fixed explicit ID.
+      // Note that (some, at least) summary tracks don't reference
+      // their group
+      const id = track.trackGroup !== SCROLLING_TRACK_GROUP
+              && Object.values(state.trackGroups).some(group => group.tracks.length && group.tracks[0] === track.id)
+          ? { id: track.id }
+          : {};
+      
+      globals.filteredTracks.push({
+        ...id,
+        kind: track.kind,
+        engineId: track.engineId,
+        name: track.name,
+        trackSortKey: track.trackSortKey,
+        trackGroup: track.trackGroup,
+        labels: track.labels,
+        config: current(track.config)
+      });
+    }
+    
+    dropTables(track.engineId, track.id);
+  },
+
+  // Remove a track group if it is removable as indicated by the
+  // |isRemovable| property of its state.
+  removeTrackGroup(state: StateDraft, args: {id: string, summaryTrackId: string}): void {
+    const trackGroup = state.trackGroups[args.id];
+    assertTrue(trackGroup.isRemovable ?? false);
+
+    removeTrackGroup(state, args.id);
+
+    if (wasFiltered(trackGroup)) {
+      delete trackGroup.wasFiltered;
+      globals.filteredTracks.push({
+        id: trackGroup.id,
+        engineId: trackGroup.engineId,
+        name: trackGroup.name,
+        collapsed: trackGroup.collapsed,
+        summaryTrackId: args.summaryTrackId
+      });
+    }
   },
 
   removeVisualisedArgTracks(state: StateDraft, args: {trackIds: string[]}) {

--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -91,11 +91,11 @@ export interface AddTrackGroupArgs {
 export type AddTrackLikeArgs = AddTrackArgs | AddTrackGroupArgs;
 
 export function isAddTrackArgs(args: AddTrackLikeArgs): args is AddTrackArgs {
-  return 'kind' in args && 'config' in args;
+  return 'kind' in args && 'trackSortKey' in args && 'config' in args;
 }
 
 export function isAddTrackGroupArgs(args: AddTrackLikeArgs): args is AddTrackGroupArgs {
-  return 'summaryTrackId' in args;
+  return 'summaryTrackId' in args; // 'collapsed' is a boolean and so quasi-defaulted
 }
 
 export interface PostedTrace {

--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -80,6 +80,24 @@ export interface AddTrackArgs {
   config: {};
 }
 
+export interface AddTrackGroupArgs {
+  id: string;
+  engineId: string;
+  name: string;
+  summaryTrackId: string;
+  collapsed: boolean;
+}
+
+export type AddTrackLikeArgs = AddTrackArgs | AddTrackGroupArgs;
+
+export function isAddTrackArgs(args: AddTrackLikeArgs): args is AddTrackArgs {
+  return 'kind' in args && 'config' in args;
+}
+
+export function isAddTrackGroupArgs(args: AddTrackLikeArgs): args is AddTrackGroupArgs {
+  return 'summaryTrackId' in args;
+}
+
 export interface PostedTrace {
   buffer: ArrayBuffer;
   title: string;
@@ -279,10 +297,7 @@ export const StateActions = {
       state: StateDraft,
       // Define ID in action so a track group can be referred to without running
       // the reducer.
-      args: {
-        engineId: string; name: string; id: string; summaryTrackId: string;
-        collapsed: boolean;
-      }): void {
+      args: AddTrackGroupArgs): void {
     state.trackGroups[args.id] = {
       engineId: args.engineId,
       name: args.name,
@@ -290,6 +305,16 @@ export const StateActions = {
       collapsed: args.collapsed,
       tracks: [args.summaryTrackId],
     };
+  },
+
+  addTrackLike(state: StateDraft, args: AddTrackLikeArgs): void {
+    if (isAddTrackGroupArgs(args)) {
+      this.addTrackGroup(state, args);
+    } else if (isAddTrackArgs(args)) {
+      this.addTrack(state, args);
+    } else {
+      assertUnreachable(args);
+    }
   },
 
   addDebugTrack(

--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -163,7 +163,6 @@ function removeTrack(state: StateDraft, trackId: string) {
 // A helper to clean the state for a given removable track group.
 function removeTrackGroup(state: StateDraft, groupId: string) {
   delete state.trackGroups[groupId];
-
   state.pinnedTracks = state.pinnedTracks.filter((id) => id !== groupId);
 }
 

--- a/ui/src/common/plugin_api.ts
+++ b/ui/src/common/plugin_api.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { TrackFilter, TrackGroupFilter } from 'src/controller/track_filter';
 import {EngineProxy} from '../common/engine';
 import {TrackControllerFactory} from '../controller/track_controller';
 import {TrackCreator} from '../frontend/track';
@@ -69,6 +70,14 @@ export interface PluginContext {
   // could be registered in dev.perfetto.CounterTrack - a whole
   // different plugin.
   registerTrack(track: TrackCreator): void;
+
+  // Register a track or track group filter. When track filtering is
+  // enabled, the core UI determines via the registered filters which
+  // tracks and track groups to show and which to suppress.
+  // Filtered tracks and track groups may later be created and
+  // shown, in which case they present a trash-can button to hide them
+  // once again.
+  registerTrackFilter(filter: TrackFilter | TrackGroupFilter): void;
 
   // Register custom functionality to specify how the plugin should handle
   // selection changes for tracks in this plugin.

--- a/ui/src/common/plugins.ts
+++ b/ui/src/common/plugins.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { TrackFilter, TrackGroupFilter, trackFilterRegistry } from '../controller/track_filter';
 import {Engine} from '../common/engine';
 import {
   TrackControllerFactory,
@@ -56,6 +57,10 @@ export class PluginContextImpl implements PluginContext {
     this.trackProviders.push(provider);
   }
 
+  registerTrackFilter(filter: TrackFilter | TrackGroupFilter): void {
+    trackFilterRegistry.register(filter);  
+  }
+
   registerOnDetailsPanelSelectionChange(
       onDetailsPanelSelectionChange: (newSelection?: Selection) => void) {
     this.onDetailsPanelSelectionChange = onDetailsPanelSelectionChange;
@@ -73,7 +78,7 @@ export class PluginContextImpl implements PluginContext {
   // PluginContext should unregister everything.
   revoke() {
     // TODO(hjd): Remove from trackControllerRegistry, trackRegistry,
-    // etc.
+    // track filters, etc.
   }
   // ==================================================================
 }

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -242,7 +242,7 @@ export interface TrackState {
   labels?: string[];
   trackSortKey: TrackSortKey;
   trackGroup?: string;
-  isUserDefined?: boolean;
+  isRemovable?: boolean;
   config: {
     trackId?: number;
     trackIds?: number[];
@@ -254,6 +254,7 @@ export interface TrackGroupState {
   engineId: string;
   name: string;
   collapsed: boolean;
+  isRemovable?: boolean;
   tracks: string[];  // Child track ids.
 }
 

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -589,8 +589,18 @@ export class TraceController extends Controller<States> {
   private async listTracks() {
     this.updateStatus('Loading tracks');
     const engine = assertExists<Engine>(this.engine);
-    const actions = await decideTracks(this.engineId, engine);
+    const actions = await this.getAddTrackActions(engine);
     globals.dispatchMultiple(actions);
+  }
+
+  private async getAddTrackActions(engine: Engine): Promise<DeferredAction[]> {
+    if (!globals.trackFilteringEnabled) {
+      return decideTracks(this.engineId, engine);
+    }
+
+    const result = await decideTracks(this.engineId, engine, true);
+    globals.filteredTracks = result.rejected;
+    return result.actions;
   }
 
   private async listThreads() {

--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -19,6 +19,8 @@ import {sqliteString} from '../base/string_utils';
 import {
   Actions,
   AddTrackArgs,
+  AddTrackGroupArgs,
+  AddTrackLikeArgs,
   DeferredAction,
 } from '../common/actions';
 import {Engine, EngineProxy} from '../common/engine';
@@ -69,6 +71,7 @@ import {
 import {addLatenciesTrack} from '../tracks/scroll_jank/event_latency_track';
 import {addTopLevelScrollTrack} from '../tracks/scroll_jank/scroll_track';
 import {THREAD_STATE_TRACK_KIND} from '../tracks/thread_state';
+import { shouldCreateTrack, shouldCreateTrackGroup } from './track_filter';
 
 const TRACKS_V2_FLAG = featureFlags.register({
   id: 'tracksV2.1',
@@ -111,6 +114,15 @@ const COUNTER_REGEX: [RegExp, CounterScaleOptions][] = [
   [ENTITY_RESIDENCY_REGEX, 'RATE'],
 ];
 
+/**
+ * Tuple of the actions to create tracks and track groups
+ * and those that were rejected by filters.
+ */
+export type TrackDecision = {
+  actions: DeferredAction[];
+  rejected: AddTrackLikeArgs[];
+}
+
 function getCounterScale(name: string): CounterScaleOptions|undefined {
   for (const [re, scale] of COUNTER_REGEX) {
     if (name.match(re)) {
@@ -120,9 +132,21 @@ function getCounterScale(name: string): CounterScaleOptions|undefined {
   return undefined;
 }
 
+/** Decide tracks without filtering. */
 export async function decideTracks(
-    engineId: string, engine: Engine): Promise<DeferredAction[]> {
-  return (new TrackDecider(engineId, engine)).decideTracks();
+  engineId: string, engine: Engine): Promise<DeferredAction[]>;
+/** Decide tracks without filtering. */
+export async function decideTracks(
+  engineId: string, engine: Engine, filter: false): Promise<DeferredAction[]>;
+/** Decide tracks with filtering. */
+export async function decideTracks(
+    engineId: string, engine: Engine, filter: true): Promise<TrackDecision>;
+
+export async function decideTracks(
+    engineId: string, engine: Engine, filter: boolean = false): Promise<DeferredAction[]|TrackDecision> {
+  
+  const result = await (new TrackDecider(engineId, engine)).decideTracks(filter);
+  return filter ? result : result.actions;
 }
 
 class TrackDecider {
@@ -131,7 +155,9 @@ class TrackDecider {
   private upidToUuid = new Map<number, string>();
   private utidToUuid = new Map<number, string>();
   private tracksToAdd: AddTrackArgs[] = [];
+  private trackGroupsToAdd: AddTrackGroupArgs[] = [];
   private addTrackGroupActions: DeferredAction[] = [];
+  private rejected: AddTrackLikeArgs[] = [];
 
   constructor(engineId: string, engine: Engine) {
     this.engineId = engineId;
@@ -396,13 +422,13 @@ class TrackDecider {
             config: {},
           });
 
-          this.addTrackGroupActions.push(Actions.addTrackGroup({
+          this.trackGroupsToAdd.push({
             engineId: this.engineId,
             summaryTrackId,
             name: parentName,
             id: trackGroup,
             collapsed: true,
-          }));
+          });
         } else {
           trackGroup = groupId;
         }
@@ -538,14 +564,13 @@ class TrackDecider {
       }
     }
 
-    const addGroup = Actions.addTrackGroup({
+    this.trackGroupsToAdd.push({
       engineId: this.engineId,
       summaryTrackId,
       name: MEM_DMA_COUNTER_NAME,
       id,
       collapsed: true,
     });
-    this.addTrackGroupActions.push(addGroup);
   }
 
   async groupGlobalIostatTracks(tag: string, group: string): Promise<void> {
@@ -586,14 +611,13 @@ class TrackDecider {
         config: {},
       });
 
-      const addGroup = Actions.addTrackGroup({
+      this.trackGroupsToAdd.push({
         engineId: this.engineId,
         summaryTrackId,
         name: groupName,
         id: value,
         collapsed: true,
       });
-      this.addTrackGroupActions.push(addGroup);
     }
   }
 
@@ -617,14 +641,13 @@ class TrackDecider {
       track.trackGroup = id;
     }
 
-    const addGroup = Actions.addTrackGroup({
+    this.trackGroupsToAdd.push({
       engineId: this.engineId,
       summaryTrackId,
       name: group,
       id,
       collapsed: true,
     });
-    this.addTrackGroupActions.push(addGroup);
   }
 
   async groupGlobalBuddyInfoTracks(): Promise<void> {
@@ -669,14 +692,13 @@ class TrackDecider {
         config: {},
       });
 
-      const addGroup = Actions.addTrackGroup({
+      this.trackGroupsToAdd.push({
         engineId: this.engineId,
         summaryTrackId,
         name: groupName,
         id: value,
         collapsed: true,
       });
-      this.addTrackGroupActions.push(addGroup);
     }
   }
 
@@ -704,14 +726,13 @@ class TrackDecider {
         config: {},
       });
 
-      const addGroup = Actions.addTrackGroup({
+      this.trackGroupsToAdd.push({
         engineId: this.engineId,
         summaryTrackId,
         name: groupName,
         id: groupUuid,
         collapsed: true,
       });
-      this.addTrackGroupActions.push(addGroup);
     }
   }
 
@@ -780,14 +801,13 @@ class TrackDecider {
     }
 
     if (groupUuid !== undefined && summaryTrackId !== undefined) {
-      const addGroup = Actions.addTrackGroup({
+      this.trackGroupsToAdd.push({
         engineId: this.engineId,
         name: 'Ftrace Events',
         id: groupUuid,
         collapsed: true,
         summaryTrackId,
       });
-      this.addTrackGroupActions.push(addGroup);
     }
   }
 
@@ -855,14 +875,13 @@ class TrackDecider {
     }
 
     for (const [groupName, groupIds] of groupNameToIds) {
-      const addGroup = Actions.addTrackGroup({
+      this.trackGroupsToAdd.push({
         engineId: this.engineId,
         summaryTrackId: groupIds.summaryTrackId,
         name: groupName,
         id: groupIds.id,
         collapsed: true,
       });
-      this.addTrackGroupActions.push(addGroup);
     }
 
     const counterResult = await engine.query(`
@@ -1488,14 +1507,13 @@ class TrackDecider {
       name: `Kernel thread summary`,
       config: {pidForColor: 2, upid: it.upid, utid: it.utid},
     });
-    const addTrackGroup = Actions.addTrackGroup({
+    this.trackGroupsToAdd.push({
       engineId: this.engineId,
       summaryTrackId,
       name: `Kernel threads`,
       id: kthreadGroupUuid,
       collapsed: true,
     });
-    this.addTrackGroupActions.push(addTrackGroup);
 
     // Set the group for all kernel threads (including kthreadd itself).
     for (; it.valid(); it.next()) {
@@ -1670,7 +1688,7 @@ class TrackDecider {
 
         const name = TrackDecider.getTrackName(
             {utid, processName, pid, threadName, tid, upid});
-        const addTrackGroup = Actions.addTrackGroup({
+        this.trackGroupsToAdd.push({
           engineId: this.engineId,
           summaryTrackId,
           name,
@@ -1680,8 +1698,6 @@ class TrackDecider {
           // jankyness.
           collapsed: !hasHeapProfiles,
         });
-
-        this.addTrackGroupActions.push(addTrackGroup);
       }
     }
   }
@@ -1755,7 +1771,7 @@ class TrackDecider {
     }
   }
 
-  async decideTracks(): Promise<DeferredAction[]> {
+  async decideTracks(filterTracks = false): Promise<TrackDecision> {
     await this.defineMaxLayoutDepthSqlFunction();
 
     // Add first the global tracks that don't require per-process track groups.
@@ -1797,7 +1813,7 @@ class TrackDecider {
     // Create the per-process track groups. Note that this won't necessarily
     // create a track per process. If a process has been completely idle and has
     // no sched events, no track group will be emitted.
-    // Will populate this.addTrackGroupActions
+    // Will populate this.trackGroupsToAdd
     await this.addProcessTrackGroups(
         this.engine.getProxy('TrackDecider::addProcessTrackGroups'));
 
@@ -1836,6 +1852,12 @@ class TrackDecider {
       }
     }
 
+    if (filterTracks) {
+      this.filterTracks();
+    }  
+
+    this.addTrackGroupActions.push(
+        ...this.trackGroupsToAdd.map(Actions.addTrackGroup));
     this.addTrackGroupActions.push(
         Actions.addTracks({tracks: this.tracksToAdd}));
 
@@ -1845,7 +1867,48 @@ class TrackDecider {
 
     this.applyDefaultCounterScale();
 
-    return this.addTrackGroupActions;
+    return { actions: this.addTrackGroupActions, rejected: this.rejected };
+  }
+
+  // Filter tracks and track groups. Any tracks belonging to an excluded
+  // group are themselves excluded regardless of track-specific filters.
+  // Any tracks not otherwise excluded that belong to an included group
+  // are implicitly included.
+  private filterTracks(): void {
+    const includedTrackGroupIds = new Set<string>();
+    const excludedTrackGroupIds = new Set<string>();
+    const includedTrackGroupSummaryTrackIds = new Set<string>();
+    const excludedTrackGroupSummaryTrackIds = new Set<string>();
+
+    this.trackGroupsToAdd = this.trackGroupsToAdd.filter(group => {
+      const included = shouldCreateTrackGroup(group);
+      if (included) {
+        includedTrackGroupIds.add(group.id);
+        includedTrackGroupSummaryTrackIds.add(group.summaryTrackId);
+      } else {
+        this.rejected.push(group);
+        excludedTrackGroupIds.add(group.id);
+        excludedTrackGroupSummaryTrackIds.add(group.summaryTrackId);
+      }
+      return included;
+    });
+
+    const hasTrackGroup = (track: AddTrackArgs): track is AddTrackArgs & {trackGroup: string} =>
+        track.trackGroup !== undefined && track.trackGroup !== SCROLLING_TRACK_GROUP;
+    const hasId = (track: AddTrackArgs): track is AddTrackArgs & {id: string} =>
+        track.id !== undefined;
+    const includedByGroup = (track: AddTrackArgs) => (hasTrackGroup(track) && includedTrackGroupIds.has(track.trackGroup))
+        || (hasId(track) && includedTrackGroupSummaryTrackIds.has(track.id));
+    const excludedByGroup = (track: AddTrackArgs) => (hasTrackGroup(track) && excludedTrackGroupIds.has(track.trackGroup))
+        || (hasId(track) && excludedTrackGroupSummaryTrackIds.has(track.id));
+    const trackFilter = (track: AddTrackArgs) => {
+      const included = shouldCreateTrack(track, includedByGroup) && !excludedByGroup(track);
+      if (!included) {
+        this.rejected.push(track);
+      }
+      return included;
+    };
+    this.tracksToAdd = this.tracksToAdd.filter(trackFilter);
   }
 
   // Some process counter tracks are tied to specific threads based on their

--- a/ui/src/controller/track_filter.ts
+++ b/ui/src/controller/track_filter.ts
@@ -66,9 +66,7 @@ abstract class ComposedFilter<FILTER extends Filter, ARGS> {
 
   abstract get kind(): string;
 
-  constructor(private readonly delegate: (filter: FILTER, args: ARGS) => FilterAction) {
-    this.delegate = delegate;
-  }
+  constructor(private readonly delegate: (filter: FILTER, args: ARGS) => FilterAction) {}
 
   push(...filters: FILTER[]): void {
     this.filters.push(...filters);

--- a/ui/src/controller/track_filter.ts
+++ b/ui/src/controller/track_filter.ts
@@ -1,0 +1,198 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Registry } from "../common/registry";
+import { AddTrackArgs, AddTrackGroupArgs } from "../common/actions";
+import { globals } from "../frontend";
+import { assertTrue } from "../base/logging";
+
+export const TRACK_GROUP_KIND = '__track_group__';
+
+export type FilterAction = 'include' | 'exclude' | 'pass';
+
+export type Filter = TrackFilter | TrackGroupFilter;
+
+export interface TrackFilter {
+  /**
+   * The kind of track to which the filter applies.
+   */
+  kind: string;
+
+  predicate: (trackArgs: AddTrackArgs) => FilterAction;
+}
+
+export interface TrackGroupFilter {
+  /**
+   * The kind of track-like element to which the filter applies.
+   * The special value |TRACK_GROUP_KIND| indicates that
+   * the filter applies to track groups, not to tracks.
+   */
+  kind: typeof TRACK_GROUP_KIND;
+
+  predicate: (trackGroupArgs: AddTrackGroupArgs) => FilterAction;
+}
+
+abstract class ComposedFilter<FILTER extends Filter, ARGS> {
+  private readonly filters: FILTER[] = [];
+
+  abstract get kind(): string;
+
+  constructor(private readonly delegate: (filter: FILTER, args: ARGS) => FilterAction) {
+    this.delegate = delegate;
+  }
+
+  push(...filters: FILTER[]): void {
+    this.filters.push(...filters);
+  }
+
+  predicate(args: ARGS): FilterAction {
+    let result: FilterAction = 'exclude';
+
+    for (const filter of this.filters) {
+      const filterResult = this.delegate(filter, args);
+      if (filterResult === 'include') {
+        result = filterResult;
+      } else if (filterResult === 'exclude') {
+        // veto
+        return filterResult;
+      }
+    }
+
+    return result;
+  }
+}
+
+class ComposedTrackFilter extends ComposedFilter<TrackFilter, AddTrackArgs> implements TrackFilter {
+  
+  constructor(public readonly kind: string, ...filters: TrackFilter[]) {
+    super((filter, args) => filter.predicate(args));
+
+    filters.forEach(filter => this.push(filter));
+  }
+
+}
+
+class ComposedTrackGroupFilter extends ComposedFilter<TrackGroupFilter, AddTrackGroupArgs> implements TrackGroupFilter {
+
+  public readonly kind = TRACK_GROUP_KIND;
+
+  constructor(...filters: TrackGroupFilter[]) {
+    super((filter, args) => filter.predicate(args));
+
+    filters.forEach(filter => this.push(filter));
+  }
+
+}
+
+function isTrackFilter(filter: Filter): filter is TrackFilter {
+  return filter.kind !== TRACK_GROUP_KIND;
+}
+
+function isTrackGroupFilter(filter: Filter): filter is TrackGroupFilter {
+  return filter.kind === TRACK_GROUP_KIND;
+}
+
+function compose<FILTER extends Filter, ARGS>(a: FILTER, b: FILTER): FILTER {
+  assertTrue(a.kind === b.kind, 'composing filters of different kinds');
+  
+  if (a instanceof ComposedFilter) {
+    (a as ComposedFilter<FILTER, ARGS>).push(b);
+    return a;
+  } else if (b instanceof ComposedFilter) {
+    (b as ComposedFilter<FILTER, ARGS>).push(a);
+    return b;
+  }
+
+  if (isTrackGroupFilter(a) && isTrackGroupFilter(b)) {
+    return new ComposedTrackGroupFilter(a, b) as unknown as FILTER;
+  } else if (isTrackFilter(a) && isTrackFilter(b)) {
+    return new ComposedTrackFilter(a.kind, a, b) as unknown as FILTER;
+  } else {
+    // Neither track group filters nor track filters
+    throw new Error('unsupported filter type');
+  }
+}
+
+/**
+ * Query whether the registered filters permit a given track to be created.
+ * If track filtering is not enabled (which it is not by default) then the
+ * result is a short-circuit `true`. Otherwise, the result is `true` if and
+ * only if some registered filter answers `'include'` _and_ no registered
+ * filter answers `'exclude'`.
+ * 
+ * @param trackArgs arguments for a track to be created
+ * @param defaultInclude an optional predicate for default inclusion of a track
+ *   that is not explicitly included or excluded by any registered filter
+ * @returns whether the track should be created according to registered filters
+ */
+export function shouldCreateTrack(trackArgs: AddTrackArgs, defaultInclude?: (trackArgs: AddTrackArgs) => boolean): boolean {
+  if (!globals.trackFilteringEnabled) {
+    return true;
+  }
+
+  if (!trackFilterRegistry.has(trackArgs.kind)) {
+    const result = defaultInclude !== undefined && defaultInclude(trackArgs);
+    return result;
+  }
+
+  const filter = trackFilterRegistry.get(trackArgs.kind) as TrackFilter;
+  const action = filter.predicate(trackArgs);
+  return action === 'include'
+      || (action !== 'exclude' && defaultInclude !== undefined && defaultInclude(trackArgs));
+}
+
+/**
+ * Query whether the registered filters permit a given track group to be created.
+ * If track filtering is not enabled (which it is not by default) then the
+ * result is a short-circuit `true`. Otherwise, the result is `true` if and
+ * only if some registered filter answers `'include'` _and_ no registered
+ * filter answers `'exclude'`.
+ * 
+ * @param trackGroupArgs arguments for a track group to be created
+ * @returns whether the track group should be created according to registered filters
+ */
+export function shouldCreateTrackGroup(trackGroupArgs: AddTrackGroupArgs): boolean {
+  if (!globals.trackFilteringEnabled) {
+    return true;
+  }
+
+  if (!trackFilterRegistry.has(TRACK_GROUP_KIND)) {
+    return false;
+  }
+
+  const filter = trackFilterRegistry.get(TRACK_GROUP_KIND) as TrackGroupFilter;
+  return filter.predicate(trackGroupArgs) === 'include';
+}
+
+class TrackFilterRegistry extends Registry<Filter> {
+  constructor() {
+    super(k => k.kind);
+  }
+
+  override register(registrant: Filter): void {
+      if (!this.has(registrant.kind)) {
+        super.register(registrant);
+      }
+
+      const extant = this.get(registrant.kind);
+      this.registry.delete(registrant.kind);
+      super.register(compose(extant, registrant));
+  }
+}
+
+/**
+ * The global track filter registry, used when track filtering is
+ * enabled via the flag on the `globals` object.
+ */
+export const trackFilterRegistry = new TrackFilterRegistry();

--- a/ui/src/controller/track_filter.ts
+++ b/ui/src/controller/track_filter.ts
@@ -19,6 +19,24 @@ import { assertTrue } from "../base/logging";
 
 export const TRACK_GROUP_KIND = '__track_group__';
 
+/**
+ * The result of a track or track group filter predicate.
+ * For a top-level tracks (in the scrolling group) and for
+ * a track group, at least one |include| result is required
+ * in order for it to be created. If any filter returns
+ * |exclude| then the track or track group is not created.
+ * A filter that has no opinion on the track or track group
+ * should return a |pass| vote.
+ * 
+ * Tracks that are included in a track group that is not
+ * the top-level scrolling group will not be created if
+ * any filter returns an |exclude| vote for it. Also, if
+ * its group is filtered out, then any |include| result
+ * is ignored because the track then is infeasible.
+ * Moreover, for a track group that is included by the
+ * filters, its member tracks are also included by default
+ * if no filter explicitly returns an |exclude| for them.
+ */
 export type FilterAction = 'include' | 'exclude' | 'pass';
 
 export type Filter = TrackFilter | TrackGroupFilter;

--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -15,7 +15,7 @@
 import {BigintMath} from '../base/bigint_math';
 import {HttpRcpEngineCustomizer} from '../common/http_rpc_engine';
 import {assertExists} from '../base/logging';
-import {Actions, DeferredAction} from '../common/actions';
+import {Actions, AddTrackLikeArgs, DeferredAction} from '../common/actions';
 import {AggregateData} from '../common/aggregation_data';
 import {Args, ArgsTree} from '../common/arg_types';
 import {
@@ -267,6 +267,8 @@ class Globals {
   private _viewOpener?: ViewOpener = undefined;
   private _allowFileDrop = true;
   private _httpRpcEngineCustomizer?: HttpRcpEngineCustomizer;
+  private _trackFilteringEnabled = false;
+  private _filteredTracks?: AddTrackLikeArgs[] = undefined;
 
   // Init from session storage since correct value may be required very early on
   private _relaxContentSecurity: boolean = window.sessionStorage.getItem(RELAX_CONTENT_SECURITY) === 'true';
@@ -652,6 +654,22 @@ class Globals {
 
   set httpRpcEngineCustomizer(httpRpcEngineCustomizer: HttpRcpEngineCustomizer | undefined) {
     this._httpRpcEngineCustomizer = httpRpcEngineCustomizer;
+  }
+
+  get trackFilteringEnabled(): boolean {
+    return this._trackFilteringEnabled;
+  }
+
+  set trackFilteringEnabled(trackFilteringEnabled: boolean) {
+    this._trackFilteringEnabled = trackFilteringEnabled;
+  }
+
+  get filteredTracks(): AddTrackLikeArgs[] {
+    return this._filteredTracks || [];
+  }
+
+  set filteredTracks(filteredTracks: AddTrackLikeArgs[] | undefined) {
+    this._filteredTracks = filteredTracks ? [...filteredTracks] : undefined;
   }
 
   makeSelection(action: DeferredAction<{}>, tabToOpen = 'current_selection') {

--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -269,7 +269,7 @@ class Globals {
   private _httpRpcEngineCustomizer?: HttpRcpEngineCustomizer;
   private _promptToLoadFromTraceProcessorShell = true;
   private _trackFilteringEnabled = false;
-  private _filteredTracks?: AddTrackLikeArgs[] = undefined;
+  private _filteredTracks: AddTrackLikeArgs[] = [];
 
   // Init from session storage since correct value may be required very early on
   private _relaxContentSecurity: boolean = window.sessionStorage.getItem(RELAX_CONTENT_SECURITY) === 'true';
@@ -674,11 +674,11 @@ class Globals {
   }
 
   get filteredTracks(): AddTrackLikeArgs[] {
-    return this._filteredTracks || [];
+    return this._filteredTracks;
   }
 
-  set filteredTracks(filteredTracks: AddTrackLikeArgs[] | undefined) {
-    this._filteredTracks = filteredTracks ? [...filteredTracks] : undefined;
+  set filteredTracks(filteredTracks: AddTrackLikeArgs[]) {
+    this._filteredTracks = [...filteredTracks];
   }
 
   makeSelection(action: DeferredAction<{}>, tabToOpen = 'current_selection') {

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -148,7 +148,8 @@ export class TrackGroupPanel extends Panel<Attrs> {
                   },
                 },
                 checkBox) :
-              ''),
+              '',
+          ...this.getTrackGroupActionButtons()),
 
         this.summaryTrack ?
             m(TrackContent,
@@ -179,6 +180,27 @@ export class TrackGroupPanel extends Panel<Attrs> {
       this.summaryTrack.onDestroy();
       this.summaryTrack = undefined;
     }
+  }
+
+  getTrackGroupActionButtons(): m.Vnode<any>[] {
+    const result: m.Vnode<any>[] = [];
+    if (this.trackGroupState.isRemovable ?? false) {
+      result.push(m('i.material-icons.track-button.action',
+        {
+          onclick: (e: MouseEvent) => {
+            globals.dispatchMultiple([
+              ...this.trackGroupState.tracks.map(trackId => Actions.removeTrack({ trackId })),
+              Actions.removeTrackGroup({
+                  id: this.trackGroupState.id,
+                  summaryTrackId: this.trackGroupState.tracks[0]
+                })
+              ]);
+            e.stopPropagation();
+          }
+        },
+        'delete'));
+    }
+    return result;
   }
 
   highlightIfTrackSelected(ctx: CanvasRenderingContext2D, size: PanelSize) {

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -115,7 +115,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
                 m('span.chip', 'metric'),
             ),
         m('.track-buttons',
-          attrs.track.getTrackShellButtons(),
+          ...this.getTrackShellButtons(attrs),
           attrs.track.getContextMenu(),
           m(TrackButton, {
             action: () => {
@@ -192,6 +192,20 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
     const dstId = this.attrs!.trackState.id;
     globals.dispatch(Actions.moveTrack({srcId, op: this.dropping, dstId}));
     this.dropping = undefined;
+  }
+
+  getTrackShellButtons(attrs: TrackShellAttrs): m.Vnode<TrackButtonAttrs>[] {
+    const result = [...attrs.track.getTrackShellButtons()];
+    if (attrs.trackState.isRemovable ?? false) {
+      result.push(m(TrackButton, {
+        action: () => globals.dispatch(Actions.removeTrack({ trackId: attrs.trackState.id })),
+        i: 'delete',
+        tooltip: 'Remove track',
+        showButton: false, // Only show on roll-over
+        fullHeight: true
+      }));
+    }
+    return result;
   }
 }
 


### PR DESCRIPTION
Introduce an API for filtering the tracks created by the Perfetto UI, customizable via a registry of filters. Record filtered tracks and track groups for later creation by user request.

By default, filtering of tracks is not engaged and the `TrackDecider` just works as before.