### PR TITLE
Flag to disable load-from-TP dialog

### DIFF
--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -267,6 +267,7 @@ class Globals {
   private _viewOpener?: ViewOpener = undefined;
   private _allowFileDrop = true;
   private _httpRpcEngineCustomizer?: HttpRcpEngineCustomizer;
+  private _promptToLoadFromTraceProcessorShell = true;
 
   // Init from session storage since correct value may be required very early on
   private _relaxContentSecurity: boolean = window.sessionStorage.getItem(RELAX_CONTENT_SECURITY) === 'true';
@@ -652,6 +653,14 @@ class Globals {
 
   set httpRpcEngineCustomizer(httpRpcEngineCustomizer: HttpRcpEngineCustomizer | undefined) {
     this._httpRpcEngineCustomizer = httpRpcEngineCustomizer;
+  }
+
+  get promptToLoadFromTraceProcessorShell(): boolean {
+    return this._promptToLoadFromTraceProcessorShell;
+  }
+
+  set promptToLoadFromTraceProcessorShell(promptToLoadFromTraceProcessorShell: boolean) {
+    this._promptToLoadFromTraceProcessorShell = promptToLoadFromTraceProcessorShell;
   }
 
   makeSelection(action: DeferredAction<{}>, tabToOpen = 'current_selection') {

--- a/ui/src/frontend/rpc_http_dialog.ts
+++ b/ui/src/frontend/rpc_http_dialog.ts
@@ -89,7 +89,7 @@ export async function CheckHttpRpcConnection(): Promise<void> {
     if (!forceUseOldVersion) return;
   }
 
-  if (tpStatus.loadedTraceName) {
+  if (tpStatus.loadedTraceName && globals.promptToLoadFromTraceProcessorShell) {
     // If a trace is already loaded in the trace processor (e.g., the user
     // launched trace_processor_shell -D trace_file.pftrace), prompt the user to
     // initialize the UI with the already-loaded trace.


### PR DESCRIPTION
Add to the globals object a flag to suppress
the dialog that prompts to open a trace
already loaded in the trace_processor_shell,
for applications that manage this externally.
