### PR TITLE
Scope key handling to the viewer page

### DIFF
--- a/ui/src/frontend/viewer_page.ts
+++ b/ui/src/frontend/viewer_page.ts
@@ -81,17 +81,22 @@ export class TrackGroup implements m.ClassComponent<TrackGroupAttrs> {
   }
 }
 
+export interface TraceViewerAttrs {
+  /** If true, scope the handling of pan/zoom/help etc. keys to the page content only. */
+  scopedKeyHandling?: boolean;
+}
+
 /**
  * Top-most level component for the viewer page. Holds tracks, brush timeline,
  * panels, and everything else that's part of the main trace viewer page.
  */
-class TraceViewer implements m.ClassComponent {
+class TraceViewer implements m.ClassComponent<TraceViewerAttrs> {
   private onResize: () => void = () => {};
   private zoomContent?: PanAndZoomHandler;
   // Used to prevent global deselection if a pan/drag select occurred.
   private keepCurrentSelection = false;
 
-  oncreate(vnode: m.CVnodeDOM) {
+  oncreate(vnode: m.CVnodeDOM<TraceViewerAttrs>) {
     const frontendLocalState = globals.frontendLocalState;
     const updateDimensions = () => {
       const rect = vnode.dom.getBoundingClientRect();
@@ -114,9 +119,11 @@ class TraceViewer implements m.ClassComponent {
 
     const panZoomEl =
         vnode.dom.querySelector('.pan-and-zoom-content') as HTMLElement;
+    const page = vnode.attrs.scopedKeyHandling ? vnode.dom as HTMLElement : undefined;
 
     this.zoomContent = new PanAndZoomHandler({
       element: panZoomEl,
+      page,
       contentOffsetX: SIDEBAR_WIDTH,
       onPanned: (pannedPx: number) => {
         const {
@@ -309,3 +316,11 @@ export const ViewerPage = createPage({
     return m(TraceViewer);
   },
 });
+
+export function createViewerPage(attrs: TraceViewerAttrs) {
+  return createPage({
+    view() {
+      return m(TraceViewer, attrs);
+    }
+  });
+}


### PR DESCRIPTION
- add an optional "page" scope to the `PanAndZoomHandler` to ignore key events from input elements in the host application UI
- export an alternative factory for the `ViewerPage` component that restricts key event handling to itself

~This is not ideal as it relies on the pointer sitting within the bounds of the timeline viewer page to infer that the user intends keyboard input to go to it, which is not as convenient as it could be for keyboard-oriented users. I welcome suggestions for a better strategy! At least in this implementation if some other field in the host application UI actually has keyboard focus and the user is typing in it, then its key events will be ignored by the `PanAndZoomHandler` regardless of where the pointer is.~