### PR TITLE
Fix dependency cycle in track filter API

### DIFF
--- a/ui/src/controller/track_filter.ts
+++ b/ui/src/controller/track_filter.ts
@@ -14,7 +14,7 @@
 
 import { Registry } from "../common/registry";
 import { AddTrackArgs, AddTrackGroupArgs } from "../common/actions";
-import { globals } from "../frontend";
+import { globals } from "../frontend/globals";
 import { assertTrue } from "../base/logging";
 
 export const TRACK_GROUP_KIND = '__track_group__';


### PR DESCRIPTION
Avoid dependency cycle through the plugin
API used by the frontend by importing globals
directly from its defining module.

_This problem was found in prototyping a work-around for multiple instantiation of the Perfetto UI in which module loading ran into uninitialized variables due to this dependency cycle._