### PR TITLE
Use trackSortKey from global instead

### DIFF
--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -64,7 +64,7 @@ import {
   VisibleState,
 } from './state';
 import {TPDuration, TPTime} from './time';
-import { STR } from './query_result';
+import {STR} from './query_result';
 
 export const DEBUG_SLICE_TRACK_KIND = 'DebugSliceTrack';
 
@@ -176,21 +176,21 @@ function wasFiltered<T extends TrackState|TrackGroupState>(item: T): item is T &
 
 function isFilteredTrack(track: Partial<AddTrackArgs>): boolean {
   return globals.trackFilteringEnabled && globals.filteredTracks
-      .some(filtered => isAddTrackArgs(filtered) && isSameTrack(filtered, track));
+      .some((filtered) => isAddTrackArgs(filtered) && isSameTrack(filtered, track));
 }
 
 // Query whether an |other| track matches enough details of a |track| as
 // to represent the same track
 function isSameTrack(track: AddTrackArgs, other: Partial<AddTrackArgs>): boolean {
-  return track.kind === other.kind
-      && track.trackGroup == other.trackGroup
+  return track.kind === other.kind &&
+      track.trackGroup == other.trackGroup &&
       // TODO: This may not be reliable. May need to deep-compare the config object
-      && track.name == other.name;
+      track.name == other.name;
 }
 
 function isFilteredTrackGroup(trackGroup: Partial<AddTrackGroupArgs>): boolean {
   return globals.trackFilteringEnabled && globals.filteredTracks
-    .some(filtered => isAddTrackGroupArgs(filtered) && filtered.id === trackGroup.id);
+    .some((filtered) => isAddTrackGroupArgs(filtered) && filtered.id === trackGroup.id);
 }
 
 function unfilterTracklike(predicate: (tracklike: AddTrackLikeArgs) => boolean) {
@@ -203,13 +203,13 @@ function unfilterTracklike(predicate: (tracklike: AddTrackLikeArgs) => boolean) 
 function unfilterTrack(track: TrackState) {
   track.isRemovable = true;
   (track as any).wasFiltered = true;
-  unfilterTracklike(filtered => isAddTrackArgs(filtered) && isSameTrack(filtered, track));
+  unfilterTracklike((filtered) => isAddTrackArgs(filtered) && isSameTrack(filtered, track));
 }
 
 function unfilterTrackGroup(trackGroup: TrackGroupState) {
   trackGroup.isRemovable = true;
   (trackGroup as any).wasFiltered = true;
-  unfilterTracklike(filtered => isAddTrackGroupArgs(filtered) && filtered.id === trackGroup.id);
+  unfilterTracklike((filtered) => isAddTrackGroupArgs(filtered) && filtered.id === trackGroup.id);
 }
 
 // A helper to delete the private tables and views created by a track.
@@ -458,7 +458,7 @@ export const StateActions = {
   // |isRemovable| property of its state.
   removeTrack(state: StateDraft, args: {trackId: string}): void {
     const track = state.tracks[args.trackId];
-    if(!track){
+    if (!track) {
       return;
     }
     assertTrue(track.isRemovable ?? false);
@@ -473,23 +473,27 @@ export const StateActions = {
       // it's a group summary track that has a fixed explicit ID.
       // Note that (some, at least) summary tracks don't reference
       // their group
-      const id = track.trackGroup !== SCROLLING_TRACK_GROUP
-              && Object.values(state.trackGroups).some(group => group.tracks.length && group.tracks[0] === track.id)
-          ? { id: track.id }
-          : {};
-      
+      const id = track.trackGroup !== SCROLLING_TRACK_GROUP &&
+              Object.values(state.trackGroups).some((group) => group.tracks.length && group.tracks[0] === track.id) ?
+          {id: track.id} :
+          {};
+
+      // sortKey from the passed state was not resolved so I used global's
+      // The error was saying something about getting Proxy
+      // Which I noticed sortKey was set to
+      const sortKey = globals.state.tracks[args.trackId].trackSortKey;
       globals.filteredTracks.push({
         ...id,
         kind: track.kind,
         engineId: track.engineId,
         name: track.name,
-        trackSortKey: track.trackSortKey,
+        trackSortKey: sortKey,
         trackGroup: track.trackGroup,
         labels: track.labels,
-        config: current(track.config)
+        config: current(track.config),
       });
     }
-    
+
     dropTables(track.engineId, track.id);
   },
 
@@ -497,7 +501,7 @@ export const StateActions = {
   // |isRemovable| property of its state.
   removeTrackGroup(state: StateDraft, args: {id: string, summaryTrackId: string}): void {
     const trackGroup = state.trackGroups[args.id];
-    if(!trackGroup){
+    if (!trackGroup) {
       return;
     }
     assertTrue(trackGroup.isRemovable ?? false);
@@ -511,7 +515,7 @@ export const StateActions = {
         engineId: trackGroup.engineId,
         name: trackGroup.name,
         collapsed: trackGroup.collapsed,
-        summaryTrackId: args.summaryTrackId
+        summaryTrackId: args.summaryTrackId,
       });
     }
   },

--- a/ui/src/common/empty_state.ts
+++ b/ui/src/common/empty_state.ts
@@ -167,5 +167,7 @@ export function createEmptyState(): State {
       textEntry: '',
       hideNonMatching: true,
     },
+
+    filteredTracks: [],
   };
 }

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -23,6 +23,7 @@ import {TopLevelScrollSelection} from '../tracks/scroll_jank/scroll_track';
 
 import {Direction} from './event_set';
 import {TPDuration, TPTime} from './time';
+import {AddTrackLikeArgs} from './actions';
 
 /**
  * A plain js object, holding objects of type |Class| keyed by string id.
@@ -564,6 +565,7 @@ export interface State {
   ftraceFilter: FtraceFilterState;
   traceConversionInProgress: boolean;
   visualisedArgs: string[];
+  filteredTracks: AddTrackLikeArgs[];
 
   /**
    * This state is updated on the frontend at 60Hz and eventually syncronised to

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -594,13 +594,7 @@ export class TraceController extends Controller<States> {
   }
 
   private async getAddTrackActions(engine: Engine): Promise<DeferredAction[]> {
-    if (!globals.trackFilteringEnabled) {
-      return decideTracks(this.engineId, engine);
-    }
-
-    const result = await decideTracks(this.engineId, engine, true);
-    globals.filteredTracks = result.rejected;
-    return result.actions;
+    return decideTracks(this.engineId, engine, globals.trackFilteringEnabled);
   }
 
   private async listThreads() {

--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -15,22 +15,22 @@
 import {BigintMath} from '../base/bigint_math';
 import {HttpRcpEngineCustomizer} from '../common/http_rpc_engine';
 import {ErrorHandler, assertExists} from '../base/logging';
-import {Actions, AddTrackLikeArgs, DeferredAction} from '../common/actions';
+import {Actions, DeferredAction} from '../common/actions';
 import {AggregateData} from '../common/aggregation_data';
 import {Args, ArgsTree} from '../common/arg_types';
 import {
   ConversionJobName,
   ConversionJobStatus,
 } from '../common/conversion_jobs';
-import { createEmptyState } from '../common/empty_state';
-import { Engine } from '../common/engine';
+import {createEmptyState} from '../common/empty_state';
+import {Engine} from '../common/engine';
 import {
   HighPrecisionTime,
   HighPrecisionTimeSpan,
 } from '../common/high_precision_time';
-import { MetricResult } from '../common/metric_data';
-import { CurrentSearchResults, SearchSummary } from '../common/search_data';
-import { CallsiteInfo, EngineConfig, ProfileType, State } from '../common/state';
+import {MetricResult} from '../common/metric_data';
+import {CurrentSearchResults, SearchSummary} from '../common/search_data';
+import {CallsiteInfo, EngineConfig, ProfileType, State} from '../common/state';
 import {Span, tpTimeFromSeconds} from '../common/time';
 import {
   TPDuration,
@@ -38,15 +38,14 @@ import {
   TPTimeSpan,
 } from '../common/time';
 
-import { Analytics, initAnalytics } from './analytics';
-import { BottomTabList } from './bottom_tab';
-import { FrontendLocalState } from './frontend_local_state';
-import { RafScheduler } from './raf_scheduler';
-import { Router } from './router';
+import {Analytics, initAnalytics} from './analytics';
+import {BottomTabList} from './bottom_tab';
+import {FrontendLocalState} from './frontend_local_state';
+import {RafScheduler} from './raf_scheduler';
+import {Router} from './router';
 import {ServiceWorkerController} from './service_worker_controller';
 import {PxSpan, TimeScale} from './time_scale';
-import { maybeShowErrorDialog } from './error_dialog';
-import { onEngineReady } from '../common/engine_ready_observer';
+import {maybeShowErrorDialog} from './error_dialog';
 
 type Dispatch = (action: DeferredAction) => void;
 type TrackDataStore = Map<string, {}>;
@@ -273,7 +272,8 @@ class Globals {
   private _httpRpcEnginePort = 9001;
   private _promptToLoadFromTraceProcessorShell = true;
   private _trackFilteringEnabled = false;
-  private _filteredTracks: AddTrackLikeArgs[] = [];
+  private _engineReadyObservers: ((engine: EngineConfig) => void)[] = [];
+
 
   // Init from session storage since correct value may be required very early on
   private _relaxContentSecurity: boolean = window.sessionStorage.getItem(RELAX_CONTENT_SECURITY) === 'true';
@@ -340,10 +340,10 @@ class Globals {
 
   set state(state: State) {
     state = assertExists(state);
-    let readyStateSet = state.engine?.ready && !this._state?.engine?.ready;
+    const readyStateSet = state.engine?.ready && !this._state?.engine?.ready;
     this._state = assertExists(state);
     if (readyStateSet) {
-      onEngineReady();
+      this.fireEngineReady(state.engine!);
     }
   }
 
@@ -544,7 +544,7 @@ class Globals {
   }
 
   get relaxContentSecurity(): boolean {
-    return !!this._relaxContentSecurity
+    return !!this._relaxContentSecurity;
   }
 
   get cachePrefix(): string {
@@ -698,12 +698,14 @@ class Globals {
     this._trackFilteringEnabled = trackFilteringEnabled;
   }
 
-  get filteredTracks(): AddTrackLikeArgs[] {
-    return this._filteredTracks;
+  private fireEngineReady(engine: EngineConfig) {
+    for (const observer of this._engineReadyObservers) {
+      observer(engine);
+    }
   }
 
-  set filteredTracks(filteredTracks: AddTrackLikeArgs[]) {
-    this._filteredTracks = [...filteredTracks];
+  addEngineReadyObserver(observer: (engine: EngineConfig) => void): void {
+      this._engineReadyObservers.push(observer);
   }
 
   makeSelection(action: DeferredAction<{}>, tabToOpen = 'current_selection') {


### PR DESCRIPTION
On removeTrack if the sortkey was a ThreadStateKey, we were not storing the correct data because the sortkey was not yet resolved. By replacing this with the sortKey from the global state it seems to not have an issue
