### PR TITLE
fix: errors when deleting process track groups

### DIFF
--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -611,8 +611,12 @@ export const StateActions = {
   toggleTrackGroupCollapsed(state: StateDraft, args: {trackGroupId: string}):
       void {
         const id = args.trackGroupId;
-        const trackGroup = assertExists(state.trackGroups[id]);
-        trackGroup.collapsed = !trackGroup.collapsed;
+        const trackGroup = state.trackGroups[id];
+        // If the track group was deleted in the interim, then
+        // we've nothing to collapse and that's fine
+        if (trackGroup) {
+          trackGroup.collapsed = !trackGroup.collapsed;
+        }
       },
 
   requestTrackReload(state: StateDraft, _: {}) {

--- a/ui/src/controller/flamegraph_controller.ts
+++ b/ui/src/controller/flamegraph_controller.ts
@@ -93,7 +93,7 @@ class TablesCache {
       // TODO(hjd): This should be LRU.
       if (this.cache.size > this.cacheSizeLimit) {
         for (const name of this.cache.values()) {
-          await this.engine.query(`drop table ${name}`);
+          await this.engine.query(`drop table if exists ${name}`);
         }
         this.cache.clear();
       }

--- a/ui/src/tracks/process_summary/index.ts
+++ b/ui/src/tracks/process_summary/index.ts
@@ -136,8 +136,8 @@ class ProcessSummaryTrackController extends TrackController<Config, Data> {
 
   onDestroy(): void {
     if (this.setup) {
-      this.query(`drop table ${this.tableName('window')}`);
-      this.query(`drop table ${this.tableName('span')}`);
+      this.query(`drop table if exists ${this.tableName('window')}`);
+      this.query(`drop table if exists ${this.tableName('span')}`);
       this.setup = false;
     }
   }


### PR DESCRIPTION
- employ a similar strategy as in the Track to cache the last known state in case it has been deleted. This ensures that continued clicking on the delete button before the track group is unrendered will not throw up assertion errors
- let the track group toggle action be tolerant of non-existent track groups. This ensures that clicking on the title area of a track group before it is unredered does not throw up assertion errors
- add missing "if exists" clauses to drop statements. These ensure, especially for the case of deleting a track group for a process that has a summary track, that the "no such table/view" errors are not thrown when deleting a track group
