### PR TITLE
Disable delete buttons during engine activity

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -436,6 +436,10 @@ $bottom-tab-padding: 10px;
       width: 22px;
       font-size: 18px;
       opacity: 0;
+
+      &.disabled {
+        filter: saturate(0) opacity(35%);
+      }
     }
 
     .track-button.show {
@@ -447,7 +451,7 @@ $bottom-tab-padding: 10px;
       align-items: center;
       justify-content: center;
 
-      &:hover {
+      &:hover:not(.disabled) {
         background-color: #ebeef9;
       }
     }
@@ -683,6 +687,10 @@ button.query-ctrl {
       width: 22px;
       font-size: 18px;
       opacity: 0;
+
+      &.disabled {
+        filter: saturate(0) opacity(35%);
+      }
     }
   }
   &:hover .track-button.action {

--- a/ui/src/common/engine.ts
+++ b/ui/src/common/engine.ts
@@ -449,6 +449,16 @@ export abstract class Engine {
   getProxy(tag: string): EngineProxy {
     return new EngineProxy(this, tag);
   }
+
+  // Query whether the engine has any data/query results pending.
+  get hasDataPending(): boolean {
+    return this.pendingParses.length > 0 ||
+      this.pendingEOFs.length > 0 ||
+      this.pendingResetTraceProcessors.length > 0 ||
+      this.pendingQueries.length > 0 ||
+      this.pendingRestoreTables.length > 0 ||
+      this.pendingComputeMetrics.length > 0;
+  }
 }
 
 // Lightweight wrapper over Engine exposing only `query` method and annotating


### PR DESCRIPTION
While the engine has operations pending in the database, disable the track deletion buttons to avoid trying to query deleted tables.

![CleanShot 2023-09-08 at 11 34 34](https://github.com/eclipsesource/perfetto/assets/1615558/79f1f780-8d5c-46e2-b2e5-2f160de1753f)
