### PR TITLE
Add support for track descriptions

### DIFF
--- a/ui/build.js
+++ b/ui/build.js
@@ -252,7 +252,7 @@ async function main() {
     bundleJs('rollup.config.js');
     copyCSSAndWASM();
     genServiceWorkerManifestJson();
-    
+
     // In order to install multiple copies of this package, it
     // cannot just symlink the compiled code
     addTask(resorbLink, [pjoin(ROOT_DIR, 'ui/out')]);
@@ -856,7 +856,7 @@ function cpR(src, dst) {
     console.log(
         'cp -r', path.relative(ROOT_DIR, src), '->', path.relative(ROOT_DIR, dst));
   }
-  fs.cpSync(src, dst, {recursive: true})
+  fs.cpSync(src, dst, {recursive: true});
 }
 
 function mklink(src, dst) {
@@ -865,8 +865,11 @@ function mklink(src, dst) {
   if (fs.existsSync(dst)) {
     if (fs.lstatSync(dst).isSymbolicLink() && fs.readlinkSync(dst) === src) {
       return;
-    } else {
+    } else if (fs.lstatSync(dst).isSymbolicLink()) {
       fs.unlinkSync(dst);
+    } else {
+      // It may have been a symlink that was resorbed
+      fs.rmSync(dst, {recursive: true});
     }
   }
   fs.symlinkSync(src, dst);
@@ -876,7 +879,7 @@ function mklink(src, dst) {
 // linking to. If it's not a link, leave it because we just don't
 // want a link.
 function resorbLink(link) {
-  const stat = fs.lstatSync(link, { throwIfNoEntry: false });
+  const stat = fs.lstatSync(link, {throwIfNoEntry: false});
   if (stat?.isSymbolicLink()) {
     const src = fs.readlinkSync(link);
     fs.unlinkSync(link);

--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -75,6 +75,7 @@ export interface AddTrackArgs {
   engineId: string;
   kind: string;
   name: string;
+  description?: string;
   labels?: string[];
   trackSortKey: TrackSortKey;
   trackGroup?: string;
@@ -85,6 +86,7 @@ export interface AddTrackGroupArgs {
   id: string;
   engineId: string;
   name: string;
+  description?: string;
   summaryTrackId: string;
   collapsed: boolean;
 }
@@ -327,6 +329,9 @@ export const StateActions = {
     args.tracks.forEach((track) => {
       const id = track.id === undefined ? generateNextId(state) : track.id;
       track.id = id;
+      track.description = track.description ?
+        `${track.name}\n\n${track.description}` :
+        track.name;
       state.tracks[id] = track as TrackState;
       this.fillUiTrackIdByTraceTrackId(state, track as TrackState, id);
       if (track.trackGroup === SCROLLING_TRACK_GROUP) {
@@ -345,13 +350,18 @@ export const StateActions = {
   addTrack(state: StateDraft, args: {
     id?: string; engineId: string; kind: string; name: string;
     trackGroup?: string; config: {}; trackSortKey: TrackSortKey;
+    description?: string;
   }): void {
     const id = args.id !== undefined ? args.id : generateNextId(state);
+    const description = args.description ?
+      `${args.name}\n\n${args.description}` :
+      args.name;
     state.tracks[id] = {
       id,
       engineId: args.engineId,
       kind: args.kind,
       name: args.name,
+      description,
       trackSortKey: args.trackSortKey,
       trackGroup: args.trackGroup,
       config: args.config,
@@ -372,11 +382,15 @@ export const StateActions = {
       // the reducer.
       args: {
         engineId: string; name: string; id: string; summaryTrackId: string;
-        collapsed: boolean;
+        collapsed: boolean; description?: string;
       }): void {
+    const description = args.description ?
+      `${args.name}\n\n${args.description}` :
+      args.name;
     state.trackGroups[args.id] = {
       engineId: args.engineId,
       name: args.name,
+      description,
       id: args.id,
       collapsed: args.collapsed,
       tracks: [args.summaryTrackId],

--- a/ui/src/common/plugin_api.ts
+++ b/ui/src/common/plugin_api.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TrackFilter, TrackGroupFilter } from 'src/controller/track_filter';
+import {TrackFilter, TrackGroupFilter} from 'src/controller/track_filter';
 import {EngineProxy} from '../common/engine';
 import {TrackControllerFactory} from '../controller/track_controller';
 import {TrackCreator} from '../frontend/track';
 import {Selection} from './state';
-import { CustomButtonArgs } from '../frontend/button_registry';
+import {CustomButtonArgs} from '../frontend/button_registry';
 
 export {EngineProxy} from '../common/engine';
 export {
@@ -37,6 +37,11 @@ export interface TrackInfo {
   // A human readable name for this specific track. It will normally be
   // displayed on the left-hand-side of the track.
   name: string;
+
+  // An optional human readable description for this specific track.
+  // If provided, it will be included in the hover tooltip on the
+  // track name on the left-hand side of the track.
+  description?: string;
 
   // An opaque config for the track.
   config: {};

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -240,6 +240,7 @@ export interface TrackState {
   engineId: string;
   kind: string;
   name: string;
+  description: string;
   labels?: string[];
   trackSortKey: TrackSortKey;
   trackGroup?: string;
@@ -253,6 +254,7 @@ export interface TrackGroupState {
   id: string;
   engineId: string;
   name: string;
+  description: string;
   collapsed: boolean;
   tracks: string[];  // Child track ids.
 }

--- a/ui/src/common/state_unittest.ts
+++ b/ui/src/common/state_unittest.ts
@@ -28,6 +28,7 @@ test('getContainingTrackId', () => {
     engineId: 'engine',
     kind: 'Foo',
     name: 'a track',
+    description: 'this is a track',
     trackSortKey: PrimaryTrackSortKey.ORDINARY_TRACK,
     config: {},
   };
@@ -37,6 +38,7 @@ test('getContainingTrackId', () => {
     engineId: 'engine',
     kind: 'Foo',
     name: 'b track',
+    description: 'this is another track',
     trackSortKey: PrimaryTrackSortKey.ORDINARY_TRACK,
     config: {},
     trackGroup: 'containsB',

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -150,7 +150,7 @@ export class TrackGroupPanel extends Panel<Attrs> {
               this.trackGroupState.collapsed ? EXPAND_DOWN : EXPAND_UP)),
           m('.title-wrapper',
             m('h1.track-title',
-              {title: name},
+              {title: trackGroup.description},
               name,
               ('namespace' in this.summaryTrackState.config) &&
                   m('span.chip', 'metric')),

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -105,7 +105,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
         m(
             'h1',
             {
-              title: attrs.trackState.name,
+              title: attrs.trackState.description,
               style: {
                 'font-size': getTitleSize(attrs.trackState.name),
               },

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -24,6 +24,7 @@ import {
   NUM,
   PluginContext,
   STR,
+  STR_NULL,
   TrackInfo,
 } from '../../common/plugin_api';
 import {TPDuration, TPTime, tpTimeToSeconds} from '../../common/time';
@@ -524,13 +525,13 @@ class CounterTrack extends Track<Config, Data> {
 
 async function globalTrackProvider(engine: EngineProxy): Promise<TrackInfo[]> {
   const result = await engine.query(`
-    select name, id
+    select name, id, description
     from (
-      select name, id
+      select name, id, description
       from counter_track
       where type = 'counter_track'
       union
-      select name, id
+      select name, id, description
       from gpu_counter_track
       where name != 'gpufreq'
     )
@@ -541,15 +542,18 @@ async function globalTrackProvider(engine: EngineProxy): Promise<TrackInfo[]> {
   const it = result.iter({
     name: STR,
     id: NUM,
+    description: STR_NULL,
   });
 
   const tracks: TrackInfo[] = [];
   for (; it.valid(); it.next()) {
     const name = it.name;
     const trackId = it.id;
+    const description = it.description?.trim() ?? undefined;
     tracks.push({
       trackKind: COUNTER_TRACK_KIND,
       name,
+      description,
       config: {
         name,
         trackId,


### PR DESCRIPTION
Add a description to the track data. Try to load it, where the schema has one, from the database. Otherwise provide some interpretive text. The latter descriptions are derived in a few different ways:

- database schema descriptions in the Perfetto documentation
- documentation from related systems (e.g., proc(5) manpage)
- mimic AGI (e.g., the display of the number of threads in a process)

Also fix the build script to account for the output directory that it needs to clean now being a real directory and not a symbolic link.
