### PR TITLE
Fix dropping unintended DB objects via accidental LIKE matches

### DIFF
--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -197,12 +197,13 @@ function unfilterTrackGroup(state: StateDraft, trackGroup: TrackGroupState) {
 //       by an explicit disposable-track protocol.
 async function dropTables(engineId: string, trackId: string) {
   const engine = assertExists(globals.engines.get(engineId));
-  const suffix = trackId.split('-').join('_');
+  const suffix = '_' + trackId.split('-').join('_');
+
   const result = await engine.query(`
       select name, type from sqlite_schema
-      where name like '%_${suffix}'
+      where substr(name, ${-suffix.length}) = '${suffix}'
       union select name, type from sqlite_temp_schema
-      where name like '%_${suffix}'`);
+      where substr(name, ${-suffix.length}) = '${suffix}'`);
 
   const it = result.iter({name: STR, type: STR});
   const dropStmts: string[] = [];


### PR DESCRIPTION
In deletion of a track, use a more precise substring matching approach to finding the tables and views to drop, instead of an error-prone LIKE pattern.
