### PR TITLE
Add subgrouping of process tracks

### DIFF
--- a/ui/src/base/array_utils.ts
+++ b/ui/src/base/array_utils.ts
@@ -31,3 +31,14 @@ export function range(n: number): number[] {
 export function allUnique(x: string[]): boolean {
   return x.length == new Set(x).size;
 }
+
+// Remove an `item` from an `array`.
+// Return whether the `array` was modified by removal of the `item`.
+export function remove(array: unknown[], item: unknown): boolean {
+  const index = array.indexOf(item);
+  if (index >= 0) {
+    array.splice(index, 1);
+    return true;
+  }
+  return false;
+}

--- a/ui/src/base/array_utils_unittest.ts
+++ b/ui/src/base/array_utils_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {allUnique, range} from './array_utils';
+import {allUnique, range, remove} from './array_utils';
 
 describe('range', () => {
   it('returns array of elements in range [0; n)', () => {
@@ -47,5 +47,24 @@ describe('allUnique', () => {
 
   it('returns true on an array with one element', () => {
     expect(allUnique(['test'])).toBeTruthy();
+  });
+});
+
+describe('remove', () => {
+  it('returns false for an array that does not have the item', () => {
+    const items = ['a', 'b', 'c'];
+    expect(remove(items, 'd')).toBe(false);
+  });
+
+  it('returns true for an array that has the item', () => {
+    const items = ['a', 'b', 'c'];
+    expect(remove(items, 'b')).toBe(true);
+    expect(items).toEqual(['a', 'c']);
+  });
+
+  it('returns true for an array that has the item multiple times', () => {
+    const items = ['a', 'b', 'c', 'b'];
+    expect(remove(items, 'b')).toBe(true);
+    expect(items).toEqual(['a', 'c', 'b']);
   });
 });

--- a/ui/src/common/plugin_api.ts
+++ b/ui/src/common/plugin_api.ts
@@ -43,6 +43,10 @@ export interface TrackInfo {
   // track name on the left-hand side of the track.
   description?: string;
 
+  // An optional human readable group name for this track.
+  // Tracks of the same group name are collected into a group of that name.
+  group?: string;
+
   // An opaque config for the track.
   config: {};
 }

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -256,6 +256,8 @@ export interface TrackGroupState {
   name: string;
   description: string;
   collapsed: boolean;
+  parentGroup?: string; // Parent group id, if a subgroup.
+  subgroups: string[]; // Child group ids.
   tracks: string[];  // Child track ids.
 }
 
@@ -948,15 +950,23 @@ export function getBuiltinChromeCategoryList(): string[] {
   ];
 }
 
-export function getContainingTrackId(state: State, trackId: string): null|
-    string {
+export function getContainingTrackIds(state: State, trackId: string): null|
+    string[] {
   const track = state.tracks[trackId];
   if (!track) {
     return null;
   }
-  const parentId = track.trackGroup;
-  if (!parentId) {
+  let groupId = track.trackGroup;
+  if (!groupId) {
     return null;
   }
-  return parentId;
+
+  const result = [];
+  while (groupId) {
+    result.unshift(groupId);
+    const trackGroup: TrackGroupState = state.trackGroups[groupId];
+    groupId = trackGroup?.parentGroup;
+  }
+
+  return result;
 }

--- a/ui/src/common/state_unittest.ts
+++ b/ui/src/common/state_unittest.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {createEmptyState} from './empty_state';
-import {getContainingTrackId, PrimaryTrackSortKey, State} from './state';
+import {getContainingTrackIds, PrimaryTrackSortKey, State} from './state';
 import {deserializeStateObject, serializeStateObject} from './upload_utils';
 
 test('createEmptyState', () => {
@@ -44,9 +44,9 @@ test('getContainingTrackId', () => {
     trackGroup: 'containsB',
   };
 
-  expect(getContainingTrackId(state, 'z')).toEqual(null);
-  expect(getContainingTrackId(state, 'a')).toEqual(null);
-  expect(getContainingTrackId(state, 'b')).toEqual('containsB');
+  expect(getContainingTrackIds(state, 'z')).toEqual(null);
+  expect(getContainingTrackIds(state, 'a')).toEqual(null);
+  expect(getContainingTrackIds(state, 'b')).toEqual(['containsB']);
 });
 
 test('state is serializable', () => {

--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -100,6 +100,10 @@ const NETWORK_TRACK_REGEX = new RegExp('^.* (Received|Transmitted)( KB)?$');
 const NETWORK_TRACK_GROUP = 'Networking';
 const ENTITY_RESIDENCY_REGEX = new RegExp('^Entity residency:');
 const ENTITY_RESIDENCY_GROUP = 'Entity residency';
+const BATTERY_TRACK_REGEX = new RegExp('^batt\\..*$');
+const BATTERY_TRACK_GROUP = 'Battery';
+const GPU_QUEUES_REGEX = new RegExp('^(Universal|Timer|DMA|Compute)( IB)?$');
+const GPU_QUEUES_GROUP = 'GPU Queues';
 
 // Sets the default 'scale' for counter tracks. If the regex matches
 // then the paired mode is used. Entries are in priority order so the
@@ -130,6 +134,10 @@ export async function decideTracks(
   return (new TrackDecider(engineId, engine)).decideTracks(filterTracks);
 }
 
+type LazyTrackGroupArgs = Partial<AddTrackGroupArgs & {
+  lazyParentGroup: () => string;
+}>;
+
 class TrackDecider {
   private engineId: string;
   private engine: Engine;
@@ -137,6 +145,7 @@ class TrackDecider {
   private utidToUuid = new Map<number, string>();
   private tracksToAdd: AddTrackArgs[] = [];
   private trackGroupsToAdd: AddTrackGroupArgs[] = [];
+  private lazyTrackGroupIds = new Map<string, () => string>;
 
   constructor(engineId: string, engine: Engine) {
     this.engineId = engineId;
@@ -317,7 +326,8 @@ class TrackDecider {
   async addCpuSchedulingTracks(): Promise<void> {
     const cpus = await this.engine.getCpus();
     const cpuToSize = await this.guessCpuSizes();
-    const groupId = this.lazyPureTrackGroup('CPU Usage', {collapsed: false});
+    const groupId = this.lazyTrackGroup('CPU Usage',
+      {collapsed: false, lazyParentGroup: this.lazyTrackGroup('CPU', {collapsed: false})});
 
     for (const cpu of cpus) {
       const size = cpuToSize.get(cpu);
@@ -364,7 +374,8 @@ class TrackDecider {
     where name = 'cpufreq';
   `);
     const maxCpuFreq = maxCpuFreqResult.firstRow({freq: NUM}).freq;
-    const groupId = this.lazyPureTrackGroup('CPU Frequencies');
+    const groupId = this.lazyTrackGroup('CPU Frequencies',
+      {lazyParentGroup: this.lazyTrackGroup('CPU', {collapsed: false})});
 
     for (const cpu of cpus) {
       // Only add a cpu freq track if we have
@@ -539,7 +550,8 @@ class TrackDecider {
   `);
     const maximumValue =
         maxGpuFreqResult.firstRow({maximumValue: NUM}).maximumValue;
-    const groupId = this.lazyPureTrackGroup('GPU Frequencies');
+    const groupId = this.lazyTrackGroup('GPU Frequencies',
+      {lazyParentGroup: this.lazyTrackGroup('GPU', {collapsed: false})});
 
     for (let gpu = 0; gpu < numGpus; gpu++) {
       // Only add a gpu freq track if we have
@@ -1782,7 +1794,7 @@ class TrackDecider {
       chromeProcessLabels: STR,
     });
 
-    const processesGroupId = this.lazyPureTrackGroup('Processes',
+    const processesGroupId = this.lazyTrackGroup('Processes',
       {description: 'Track groups for each active process.'});
 
     for (; it.valid(); it.next()) {
@@ -1880,6 +1892,150 @@ class TrackDecider {
     }
   }
 
+  async addSurfaceFlingerTrackGroups(engine: EngineProxy): Promise<void> {
+    const result = await engine.query(`
+    select distinct gpu_track.id as trackId, gpu_track.name as trackName, frame_slice.layer_name as layerName
+    from frame_slice, gpu_track
+    where frame_slice.track_id = gpu_track.id
+      and gpu_track.name is not null
+      and frame_slice.layer_name is not null
+    `);
+
+    const it = result.iter({
+      trackId: NUM,
+      // trackName: STR,
+      layerName: STR,
+    });
+
+    const layersByTrack = new Map<number, string>();
+    for (; it.valid(); it.next()) {
+      const trackId = it.trackId;
+      // const trackName = it.trackName;
+      const layerName = it.layerName;
+      layersByTrack.set(trackId, layerName);
+    }
+
+    const getTrackId = (track: AddTrackArgs): number|undefined => {
+      return ('trackIds' in track.config && Array.isArray(track.config.trackIds)) ?
+        track.config.trackIds[0] :
+        undefined;
+    };
+    const layerGroup = (layerName: string) => this.lazyTrackGroup(
+      `Layer - ${layerName}`, {lazyParentGroup: this.lazyTrackGroup('SurfaceFlinger Events')});
+    const layerSubgroups = new Map<string, Map<string, string>>();
+    const layerSubgroup = (layerName: string, subgroup: string) => {
+      let subgroups = layerSubgroups.get(layerName);
+      if (subgroups === undefined) {
+        subgroups = new Map<string, string>();
+        layerSubgroups.set(layerName, subgroups);
+      }
+      let result = subgroups.get(subgroup);
+      if (result === undefined) {
+        result = this.createPureTrackGroup(uuidv4(), subgroup,
+          {lazyParentGroup: layerGroup(layerName)}).id;
+        subgroups.set(subgroup, result);
+      }
+      return result;
+    };
+
+    for (const track of this.tracksToAdd) {
+      if (track.trackGroup === SCROLLING_TRACK_GROUP) {
+        const trackId = getTrackId(track);
+        const layerName = trackId !== undefined ?
+          layersByTrack.get(trackId) :
+          undefined;
+        if (layerName) {
+          const subgroupName = track.name.startsWith('Buffer:') ? 'Buffers' : undefined;
+          if (subgroupName) {
+            // Group the track
+            track.trackGroup = layerSubgroup(layerName, subgroupName);
+            // And rename it
+            const bufferMatch = /^Buffer: (\d+)?/.exec(track.name);
+            if (bufferMatch) {
+              track.description = track.description ?? track.name;
+              track.name = `Buffer ${bufferMatch[1]}`;
+            }
+          } else {
+            track.trackGroup = layerGroup(layerName)();
+
+            // Rename the track, if applicable
+            const bufferMatch = /^(SF|APP|GPU|Display)_(\d+)?/
+              .exec(track.name);
+            if (bufferMatch) {
+              switch (bufferMatch[1]) {
+                case 'APP':
+                  track.name = `Application - Buffer ${bufferMatch[2]}`;
+                  track.description = track.description ?? 'The time from when the buffer was dequeued by the app to when it was enqueued back.';
+                  break;
+                case 'GPU':
+                  track.name = `Wait for GPU - Buffer ${bufferMatch[2]}`;
+                  track.description = track.description ?? 'The duration the buffer was owned by the GPU. This is the time from when the buffer was sent to the GPU to when the GPU finished its work on the buffer. This does not indicate that the GPU was working only on this buffer during this time.';
+                  break;
+                case 'SF':
+                  track.name = `Composition - Buffer ${bufferMatch[2]}`;
+                  track.description = track.description ?? 'The time from when SurfaceFlinger latched on to the buffer and sent for composition to when it was sent to the display.';
+                  break;
+                case 'Display':
+                  track.name = 'On Display';
+                  track.description = track.description ?? 'The duration the frame was displayed on screen.';
+                  break;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  addGPUMasterGroup(): void {
+    const gpuGroup = this.lazyTrackGroup('GPU', {collapsed: false});
+
+    const groupsToCollect: AddTrackGroupArgs[] = [];
+    for (const group of this.trackGroupsToAdd) {
+      if (group.name.startsWith('GPU ') && !group.parentGroup) {
+        groupsToCollect.push(group);
+      }
+    }
+    groupsToCollect.forEach((group) => group.parentGroup = gpuGroup());
+
+    // Collect some tracks, too
+    for (const track of this.tracksToAdd) {
+      if (track.name.startsWith('Vulkan ')) {
+        track.trackGroup = gpuGroup();
+      }
+    }
+  }
+
+  sortTopTrackGroups(): void {
+    // Must create parent groups before subgroups.
+    const topGroups: AddTrackGroupArgs[] = [];
+    for (let i = 0; i < this.trackGroupsToAdd.length; i++) {
+      const group = this.trackGroupsToAdd[i];
+      if (!group.parentGroup) {
+        topGroups.push(group);
+        this.trackGroupsToAdd.splice(i, 1);
+        i--;
+      }
+    }
+
+    // Sort the top-level Processes group to the bottom
+    const comparator = (g1: AddTrackGroupArgs, g2: AddTrackGroupArgs) => {
+      if (g1 === g2) {
+        return 0;
+      }
+      if (g1.name === 'Processes') {
+        return +1; // Last
+      }
+      if (g2.name === 'Processes') {
+        return -1; // Last
+      }
+      return g1.name.localeCompare(g2.name);
+    };
+
+    topGroups.sort(comparator);
+    this.trackGroupsToAdd.unshift(...topGroups);
+  }
+
   private async computeThreadOrderingMetadata(): Promise<UtidToTrackSortKey> {
     const result = await this.engine.query(`
     select
@@ -1934,16 +2090,9 @@ class TrackDecider {
     const promises = pluginManager.findPotentialTracks(this.engine);
     const groups = await Promise.all(promises);
 
-    const groupIds: Record<string, string> = {};
     const grouperator = (track: TrackInfo): string => {
       if (track.group) {
-        let groupId = groupIds[track.group];
-        if (!groupId) {
-          groupId = uuidv4();
-          groupIds[track.group] = groupId;
-          this.createPureTrackGroup(groupId, track.group);
-        }
-        return groupId;
+        return this.lazyTrackGroup(track.group)();
       }
       return SCROLLING_TRACK_GROUP;
     };
@@ -1994,6 +2143,8 @@ class TrackDecider {
     await this.groupTracksByRegex(NETWORK_TRACK_REGEX, NETWORK_TRACK_GROUP);
     await this.groupTracksByRegex(
         ENTITY_RESIDENCY_REGEX, ENTITY_RESIDENCY_GROUP);
+    await this.groupTracksByRegex(BATTERY_TRACK_REGEX, BATTERY_TRACK_GROUP);
+    await this.groupTracksByRegex(GPU_QUEUES_REGEX, GPU_QUEUES_GROUP);
 
     // Pre-group all kernel "threads" (actually processes) if this is a linux
     // system trace. Below, addProcessTrackGroups will skip them due to an
@@ -2035,6 +2186,10 @@ class TrackDecider {
         this.engine.getProxy('TrackDecider::addThreadCpuSampleTracks'));
     await this.addLogsTrack(this.engine.getProxy('TrackDecider::addLogsTrack'));
 
+    await this.addSurfaceFlingerTrackGroups(
+      this.engine.getProxy('TrackDecider::addSurfaceflingerTrackGroups'));
+    this.addGPUMasterGroup();
+
     // TODO(hjd): Move into plugin API.
     {
       const result = scrollJankDecideTracks(this.engine, (utid, upid) => {
@@ -2045,6 +2200,8 @@ class TrackDecider {
         this.tracksToAdd.push(...tracksToAdd);
       }
     }
+
+    this.sortTopTrackGroups();
 
     const actions: DeferredAction[] = [];
     if (filterTracks) {
@@ -2178,27 +2335,38 @@ class TrackDecider {
     }
   }
 
-  lazyPureTrackGroup(name: string,
-      details?: Partial<AddTrackGroupArgs>): (() => string) {
-    let group: AddTrackGroupArgs | undefined;
-    return (): string => {
-      if (!group) {
-        group = this.createPureTrackGroup(uuidv4(), name, details);
-      }
-      return group.id;
-    };
+  lazyTrackGroup(name: string,
+      details?: LazyTrackGroupArgs): (() => string) {
+    let result = this.lazyTrackGroupIds.get(name);
+    if (result === undefined) {
+      let group: AddTrackGroupArgs | undefined;
+      result = (): string => {
+        if (!group) {
+          group = this.createPureTrackGroup(uuidv4(), name, details);
+        }
+        return group.id;
+      };
+      this.lazyTrackGroupIds.set(name, result);
+    }
+    return result;
   }
 
   createPureTrackGroup(id: string, name: string,
-      details: Partial<AddTrackGroupArgs> = {}): AddTrackGroupArgs {
+      details: LazyTrackGroupArgs = {}): AddTrackGroupArgs {
+    const {lazyParentGroup, ...staticDetails} = details;
+
     const result: AddTrackGroupArgs = {
       id,
       engineId: this.engineId,
       name,
       summaryTrackId: id, // Group needs a summary track, even if it's blank
       collapsed: true,
-      ...details,
+      ...staticDetails,
     };
+    if (lazyParentGroup) {
+      result.parentGroup = lazyParentGroup();
+    }
+
     this.trackGroupsToAdd.push(result);
     this.tracksToAdd.push(this.blankSummaryTrack(id));
     return result;

--- a/ui/src/frontend/scroll_helper.ts
+++ b/ui/src/frontend/scroll_helper.ts
@@ -17,7 +17,7 @@ import {
   HighPrecisionTime,
   HighPrecisionTimeSpan,
 } from '../common/high_precision_time';
-import {getContainingTrackId} from '../common/state';
+import {getContainingTrackIds} from '../common/state';
 import {TPTime} from '../common/time';
 
 import {globals} from './globals';
@@ -121,10 +121,18 @@ export function verticalScrollToTrack(
     return;
   }
 
+  let trackGroupId: string | undefined;
+  let trackSubgroupId: string | undefined;
   let trackGroup = null;
-  const trackGroupId = getContainingTrackId(globals.state, trackIdString);
-  if (trackGroupId) {
+  let trackSubgroup = null;
+  const containingIds = getContainingTrackIds(globals.state, trackIdString);
+  if (containingIds) {
+    trackGroupId = containingIds[0];
+    trackSubgroupId = containingIds[1];
     trackGroup = document.querySelector('#track_' + trackGroupId);
+    if (trackSubgroupId) {
+      trackSubgroup = document.querySelector('#track_' + trackSubgroupId);
+    }
   }
 
   if (!trackGroupId || !trackGroup) {
@@ -138,9 +146,10 @@ export function verticalScrollToTrack(
     // After the track exists in the dom, it will be scrolled to.
     globals.frontendLocalState.scrollToTrackId = trackId;
     globals.dispatch(Actions.toggleTrackGroupCollapsed({trackGroupId}));
+    // TODO(cwd): Handle the track subgroup
     return;
   } else {
-    trackGroup.scrollIntoView({behavior: 'smooth', block: 'nearest'});
+    (trackSubgroup ?? trackGroup).scrollIntoView({behavior: 'smooth', block: 'nearest'});
   }
 }
 

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -131,13 +131,16 @@ export class TrackGroupPanel extends Panel<Attrs> {
       child = this.summaryTrackState.labels.join(', ');
     }
 
-    const depth: (group?: TrackGroupState) => number = (group?: TrackGroupState) =>
-      group?.parentGroup ? depth(globals.state.trackGroups[group.parentGroup]) + 1 : 0;
+    const depth: (group?: TrackGroupState) => number =
+      (group?: TrackGroupState) =>
+        group?.parentGroup ?
+          depth(globals.state.trackGroups[group.parentGroup]) + 1 :
+          0;
     const indent = (depth: number) => depth <= 0 ?
       {} :
-      {style: {marginLeft: `${depth}em`}}
+      {style: {marginLeft: `${depth/2}rem`}};
 
-    const attributes = indent(depth(trackGroup));
+    const titleStyling = indent(depth(trackGroup));
     return m(
         `.track-group-panel[collapsed=${collapsed}]`,
         {id: 'track_' + this.trackGroupId},
@@ -153,11 +156,11 @@ export class TrackGroupPanel extends Panel<Attrs> {
           },
 
           m('.fold-button',
-            {...attributes},
+            {...titleStyling},
             m('i.material-icons',
               this.trackGroupState.collapsed ? EXPAND_DOWN : EXPAND_UP)),
           m('.title-wrapper',
-            {...attributes},
+            {...titleStyling},
             m('h1.track-title',
               {title: trackGroup.description},
               name,

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -18,7 +18,7 @@ import m from 'mithril';
 import {assertExists} from '../base/logging';
 import {Actions} from '../common/actions';
 import {
-  getContainingTrackId,
+  getContainingTrackIds,
   TrackGroupState,
   TrackState,
 } from '../common/state';
@@ -103,8 +103,8 @@ export class TrackGroupPanel extends Panel<Attrs> {
     const searchIndex = globals.state.searchIndex;
     if (searchIndex !== -1) {
       const trackId = globals.currentSearchResults.trackIds[searchIndex];
-      const parentTrackId = getContainingTrackId(globals.state, trackId);
-      if (parentTrackId === attrs.trackGroupId) {
+      const parentTrackIds = getContainingTrackIds(globals.state, trackId);
+      if (parentTrackIds && parentTrackIds.includes(attrs.trackGroupId)) {
         highlightClass = 'flash';
       }
     }
@@ -131,6 +131,13 @@ export class TrackGroupPanel extends Panel<Attrs> {
       child = this.summaryTrackState.labels.join(', ');
     }
 
+    const depth: (group?: TrackGroupState) => number = (group?: TrackGroupState) =>
+      group?.parentGroup ? depth(globals.state.trackGroups[group.parentGroup]) + 1 : 0;
+    const indent = (depth: number) => depth <= 0 ?
+      {} :
+      {style: {marginLeft: `${depth}em`}}
+
+    const attributes = indent(depth(trackGroup));
     return m(
         `.track-group-panel[collapsed=${collapsed}]`,
         {id: 'track_' + this.trackGroupId},
@@ -146,9 +153,11 @@ export class TrackGroupPanel extends Panel<Attrs> {
           },
 
           m('.fold-button',
+            {...attributes},
             m('i.material-icons',
               this.trackGroupState.collapsed ? EXPAND_DOWN : EXPAND_UP)),
           m('.title-wrapper',
+            {...attributes},
             m('h1.track-title',
               {title: trackGroup.description},
               name,
@@ -209,7 +218,8 @@ export class TrackGroupPanel extends Panel<Attrs> {
         m(TrackButton, {
           action: (e: MouseEvent) => {
             globals.dispatchMultiple([
-              ...this.trackGroupState.tracks.map((trackId) => Actions.removeTrack({trackId})),
+              ...this.trackGroupState.tracks.map(
+                (trackId) => Actions.removeTrack({trackId})),
               Actions.removeTrackGroup({
                   id: this.trackGroupState.id,
                   summaryTrackId: this.trackGroupState.tracks[0],

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -31,6 +31,7 @@ import {trackRegistry} from './track_registry';
 import {
   drawVerticalLineAtTime,
 } from './vertical_line_helper';
+import {SCROLLING_TRACK_GROUP, getContainingTrackIds} from '../common/state';
 
 function getTitleSize(title: string): string|undefined {
   const length = title.length;
@@ -90,6 +91,16 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       }
     }
 
+    const depth = attrs.trackState.trackGroup === SCROLLING_TRACK_GROUP ?
+      0 :
+      getContainingTrackIds(globals.state, attrs.trackState.id)?.length ?? 0;
+    const titleStyling: Record<string, string|undefined> = {
+      fontSize: getTitleSize(attrs.trackState.name),
+    };
+    if (depth > 0) {
+      titleStyling.marginLeft = `${depth/2}rem`;
+    }
+
     const dragClass = this.dragging ? `drag` : '';
     const dropClass = this.dropping ? `drop-${this.dropping}` : '';
     return m(
@@ -106,9 +117,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
             'h1',
             {
               title: attrs.trackState.description,
-              style: {
-                'font-size': getTitleSize(attrs.trackState.name),
-              },
+              style: titleStyling,
             },
             attrs.trackState.name,
             ('namespace' in attrs.trackState.config) &&

--- a/ui/src/frontend/viewer_page.ts
+++ b/ui/src/frontend/viewer_page.ts
@@ -32,6 +32,7 @@ import {TimeSelectionPanel} from './time_selection_panel';
 import {DISMISSED_PANNING_HINT_KEY} from './topbar';
 import {TrackGroupPanel} from './track_group_panel';
 import {TrackPanel} from './track_panel';
+import {TrackGroupState} from '../common/state';
 
 const SIDEBAR_WIDTH = 256;
 
@@ -200,7 +201,7 @@ class TraceViewer implements m.ClassComponent<TraceViewerAttrs> {
               visibleTimeScale.pxToHpTime(startPx).toTPTime('floor'),
               visibleTimeScale.pxToHpTime(endPx).toTPTime('ceil'),
           );
-          
+
           // we need to encount for the embedded scenario so we may not be at the very top
           // we remove the topbar height as it is added again in the rendering of the panel container
           const panelBounds = panZoomEl.getBoundingClientRect();
@@ -243,7 +244,7 @@ class TraceViewer implements m.ClassComponent<TraceViewerAttrs> {
     const scrollingPanels: AnyAttrsVnode[] = globals.state.scrollingTracks.map(
         (id) => m(TrackPanel, {key: id, id, selectable: true}));
 
-    for (const group of Object.values(globals.state.trackGroups)) {
+    const renderGroup = (group: TrackGroupState, panels: AnyAttrsVnode[]) => {
       const headerPanel = m(TrackGroupPanel, {
         trackGroupId: group.id,
         key: `trackgroup-${group.id}`,
@@ -251,9 +252,14 @@ class TraceViewer implements m.ClassComponent<TraceViewerAttrs> {
       });
 
       const childTracks: AnyAttrsVnode[] = [];
-      // The first track is the summary track, and is displayed as part of the
-      // group panel, we don't want to display it twice so we start from 1.
       if (!group.collapsed) {
+        // Recursively render subgroups, first
+        group.subgroups.map((id) => globals.state.trackGroups[id])
+          .filter(Boolean)
+          .forEach((subgroup) => renderGroup(subgroup, childTracks));
+
+        // The first track is the summary track, and is displayed as part of the
+        // group panel, we don't want to display it twice so we start from 1.
         for (let i = 1; i < group.tracks.length; ++i) {
           const id = group.tracks[i];
           childTracks.push(m(TrackPanel, {
@@ -263,12 +269,16 @@ class TraceViewer implements m.ClassComponent<TraceViewerAttrs> {
           }));
         }
       }
-      scrollingPanels.push(m(TrackGroup, {
+      panels.push(m(TrackGroup, {
         header: headerPanel,
         collapsed: group.collapsed,
         childTracks,
       } as TrackGroupAttrs));
-    }
+    };
+
+    Object.values(globals.state.trackGroups)
+      .filter((group) => group.parentGroup === undefined)
+      .forEach((group) => renderGroup(group, scrollingPanels));
 
     const overviewPanel = [];
     if (OVERVIEW_PANEL_FLAG.get()) {
@@ -321,6 +331,6 @@ export function createViewerPage(attrs: TraceViewerAttrs) {
   return createPage({
     view() {
       return m(TraceViewer, attrs);
-    }
+    },
   });
 }

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -562,6 +562,7 @@ async function globalTrackProvider(engine: EngineProxy): Promise<TrackInfo[]> {
       trackKind: COUNTER_TRACK_KIND,
       name,
       description,
+      group: 'GPU Counters',
       config: {
         name,
         trackId,


### PR DESCRIPTION
- introduce a general facility for abritrary levels of subgrouping in track groups and apply it to the process tracks and some others of the top-level tracks, including CPU tracks and GPU counters
- simplify the process memory counter track names now they are grouped
