### PR TITLE
Clearly identify different frame buffer events

### DIFF
--- a/ui/src/common/plugin_api.ts
+++ b/ui/src/common/plugin_api.ts
@@ -63,7 +63,11 @@ export interface PluginContext {
   // 'TrackController' and a 'Track'. In more recent versions of the UI
   // the functionality of |TrackController| has been merged into Track so
   // |TrackController|s are not necessary in new code.
-  registerTrackController(track: TrackControllerFactory): void;
+  // Unless |supersede| is true, then an attempt to register a |track|
+  // controller factory for a |track| kind that is already registered will
+  // throw an error.
+  registerTrackController(track: TrackControllerFactory,
+    supersede?: boolean): void;
 
   // Register a |TrackProvider|. |TrackProvider|s return |TrackInfo| for
   // all potential tracks in a trace. The core UI selects some of these
@@ -79,7 +83,10 @@ export interface PluginContext {
   // which returns GPU counter tracks. The counter track factory itself
   // could be registered in dev.perfetto.CounterTrack - a whole
   // different plugin.
-  registerTrack(track: TrackCreator): void;
+  // Unless |supersede| is true, then an attempt to register a |track|
+  // controller factory for a |track| kind that is already registered will
+  // throw an error.
+  registerTrack(track: TrackCreator, supersede?: boolean): void;
 
   // Register a track or track group filter. When track filtering is
   // enabled, the core UI determines via the registered filters which

--- a/ui/src/common/plugins.ts
+++ b/ui/src/common/plugins.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { TrackFilter, TrackGroupFilter, trackFilterRegistry } from '../controller/track_filter';
+import {TrackFilter, TrackGroupFilter, trackFilterRegistry} from '../controller/track_filter';
 import {Engine} from '../common/engine';
 import {
   TrackControllerFactory,
@@ -29,7 +29,7 @@ import {
 } from './plugin_api';
 import {Registry} from './registry';
 import {Selection} from './state';
-import { CustomButton, CustomButtonArgs, customButtonRegistry } from '../frontend/button_registry';
+import {CustomButton, CustomButtonArgs, customButtonRegistry} from '../frontend/button_registry';
 
 // Every plugin gets its own PluginContext. This is how we keep track
 // what each plugin is doing and how we can blame issues on particular
@@ -46,12 +46,12 @@ export class PluginContextImpl implements PluginContext {
 
   // ==================================================================
   // The plugin facing API of PluginContext:
-  registerTrackController(track: TrackControllerFactory): void {
-    trackControllerRegistry.register(track);
+  registerTrackController(track: TrackControllerFactory,
+      supersede = false): void {
+    trackControllerRegistry.register(track, supersede);
   }
-
-  registerTrack(track: TrackCreator): void {
-    trackRegistry.register(track);
+  registerTrack(track: TrackCreator, supersede = false): void {
+    trackRegistry.register(track, supersede);
   }
 
   registerTrackProvider(provider: TrackProvider) {
@@ -59,7 +59,7 @@ export class PluginContextImpl implements PluginContext {
   }
 
   registerTrackFilter(filter: TrackFilter | TrackGroupFilter): void {
-    trackFilterRegistry.register(filter);  
+    trackFilterRegistry.register(filter);
   }
 
   registerOnDetailsPanelSelectionChange(

--- a/ui/src/common/registry.ts
+++ b/ui/src/common/registry.ts
@@ -27,9 +27,11 @@ export class Registry<T> {
     this.key = key;
   }
 
-  register(registrant: T) {
+  // Register a |registrant| with the option to |supersede|
+  // an existing registrant for the same key, if any.
+  register(registrant: T, supersede = false) {
     const kind = this.key(registrant);
-    if (this.registry.has(kind)) {
+    if (!supersede && this.registry.has(kind)) {
       throw new Error(`Registrant ${kind} already exists in the registry`);
     }
     this.registry.set(kind, registrant);

--- a/ui/src/frontend/hsluv_cache.ts
+++ b/ui/src/frontend/hsluv_cache.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {hsluvToHex} from 'hsluv';
+import {hexToHsluv, hsluvToHex} from 'hsluv';
 
 class HsluvCache {
   storage = new Map<number, string>();
@@ -36,4 +36,22 @@ const cache = new HsluvCache();
 export function cachedHsluvToHex(
     hue: number, saturation: number, lightness: number): string {
   return cache.get(hue, saturation, lightness);
+}
+
+const textColorCache = new Map<string, string>();
+
+export function contrastingTextColor(color: string): string;
+export function contrastingTextColor(hue: number,
+  saturation: number, lightness: number): string;
+export function contrastingTextColor(colorOrHue: string|number,
+    saturation?: number, lightness?: number): string {
+  const color = typeof colorOrHue === 'string' ? colorOrHue :
+    hsluvToHex([colorOrHue, saturation ?? 100, lightness ?? 60]);
+  let result = textColorCache.get(color);
+  if (!result) {
+    const lightness = hexToHsluv(color)[2];
+    result = lightness > 65 ? '#404040' : '#ffffff';
+    textColorCache.set(color, result);
+  }
+  return result;
 }

--- a/ui/src/frontend/hsluv_cache.ts
+++ b/ui/src/frontend/hsluv_cache.ts
@@ -38,20 +38,24 @@ export function cachedHsluvToHex(
   return cache.get(hue, saturation, lightness);
 }
 
-const textColorCache = new Map<string, string>();
+// A mapping of slice colors to contrasting colors
+// suitable for rendering text on them. Keys and
+// values are both hex codes of the form #rrggbb.
+const contrastingTextColorCodeCache = new Map<string, string>();
 
-export function contrastingTextColor(color: string): string;
-export function contrastingTextColor(hue: number,
-  saturation: number, lightness: number): string;
-export function contrastingTextColor(colorOrHue: string|number,
-    saturation?: number, lightness?: number): string {
-  const color = typeof colorOrHue === 'string' ? colorOrHue :
-    hsluvToHex([colorOrHue, saturation ?? 100, lightness ?? 60]);
-  let result = textColorCache.get(color);
+// Obtain a color code contrasting to the given |color|
+// that is suitable for painting text on it.
+// @param color hex code in the form #rrggbb of
+//   something like a slice rendered in the track
+// @returns a color hex code for contrasting text,
+//   which will either be white for a dark |color|
+//   or a dark grey-black for a light |color|
+export function contrastingTextColorCode(color: string): string {
+  let result = contrastingTextColorCodeCache.get(color);
   if (!result) {
     const lightness = hexToHsluv(color)[2];
-    result = lightness > 65 ? '#404040' : '#ffffff';
-    textColorCache.set(color, result);
+    result = lightness > 65 ? '#202020' : '#ffffff';
+    contrastingTextColorCodeCache.set(color, result);
   }
   return result;
 }

--- a/ui/src/tracks/async_slices/index.ts
+++ b/ui/src/tracks/async_slices/index.ts
@@ -21,15 +21,9 @@ import {
   TrackController,
 } from '../../controller/track_controller';
 import {NewTrackArgs, Track} from '../../frontend/track';
-import {ChromeSliceTrack, Instant} from '../chrome_slices';
-import {contrastingTextColor} from '../../frontend/hsluv_cache';
+import {ChromeSliceTrack} from '../chrome_slices';
 
 export const ASYNC_SLICE_TRACK_KIND = 'AsyncSliceTrack';
-
-const SLICE_HEIGHT = 18;
-const DIAMOND_WIDTH_PX = 16;
-const HALF_SLICE_HEIGHT = SLICE_HEIGHT / 2;
-const HALF_DIAMOND_WIDTH_PX = DIAMOND_WIDTH_PX / 2;
 
 export interface Config {
   maxDepth: number;
@@ -48,7 +42,7 @@ export interface Data extends TrackData {
   isIncomplete: Uint16Array;
 }
 
-class AsyncSliceTrackController extends TrackController<Config, Data> {
+export class AsyncSliceTrackController extends TrackController<Config, Data> {
   static readonly kind = ASYNC_SLICE_TRACK_KIND;
   private maxDurNs: TPDuration = 0n;
 
@@ -142,33 +136,6 @@ export class AsyncSliceTrack extends ChromeSliceTrack {
   static readonly kind = ASYNC_SLICE_TRACK_KIND;
   static create(args: NewTrackArgs): Track {
     return new AsyncSliceTrack(args);
-  }
-
-  drawChevron(ctx: CanvasRenderingContext2D, instant?: Instant) {
-    if (this.trackState.name.search(/^Buffer:? \d+/) !== 0) {
-      // Not a GPU buffer, so draw a regular chevron
-      return super.drawChevron(ctx);
-    }
-    if (!instant?.title) {
-      // Don't need a diamond if there's no text to fill
-      return super.drawChevron(ctx);
-    }
-
-    // Draw a diamond at a fixed location and size with the initial
-    // of the instant's title at the centre. Should be used with
-    // ctx.translate and ctx.scale to alter location and size.
-    ctx.beginPath();
-    ctx.moveTo(0, 0);
-    ctx.lineTo(HALF_DIAMOND_WIDTH_PX, HALF_SLICE_HEIGHT);
-    ctx.lineTo(0, SLICE_HEIGHT);
-    ctx.lineTo(-HALF_DIAMOND_WIDTH_PX, HALF_SLICE_HEIGHT);
-    ctx.lineTo(0, 0);
-    ctx.fill();
-
-    const x = 0;
-    const y = (SLICE_HEIGHT + instant.tmAscent) / 2;
-    ctx.fillStyle = contrastingTextColor(instant.color);
-    ctx.fillText(instant.title.substring(0, 1).toUpperCase(), x, y);
   }
 }
 

--- a/ui/src/tracks/chrome_slices/index.ts
+++ b/ui/src/tracks/chrome_slices/index.ts
@@ -56,6 +56,18 @@ export interface Data extends TrackData {
   cpuTimeRatio?: Float64Array;
 }
 
+// Like a Slice, but only of the instantaneous kind and
+// only enough information to render it in the track
+export interface Instant {
+  id: number;
+  start: bigint;
+  depth: number;
+  title: string;
+  color: string;
+  tmAscent: number;
+  tmWidth: number;
+}
+
 export class ChromeSliceTrackController extends TrackController<Config, Data> {
   static kind = SLICE_TRACK_KIND;
   private maxDurNs: TPDuration = 0n;
@@ -197,7 +209,9 @@ export class ChromeSliceTrack extends Track<Config, Data> {
     ctx.textAlign = 'center';
 
     // measuretext is expensive so we only use it once.
-    const charWidth = ctx.measureText('ACBDLqsdfg').width / 10;
+    const charTM = ctx.measureText('ACBDLqsdfg');
+    const charWidth = charTM.width / 10;
+    const charAscent = charTM.actualBoundingBoxAscent;
 
     // The draw of the rect on the selected slice must happen after the other
     // drawings, otherwise it would result under another rect.
@@ -253,6 +267,16 @@ export class ChromeSliceTrack extends Track<Config, Data> {
       // D       B
       // Then B, C, D and back to A:
       if (isInstant) {
+        const instant: Instant = {
+          id: sliceId,
+          depth,
+          title,
+          start: tStart,
+          color,
+          tmAscent: charAscent,
+          tmWidth: charWidth,
+        };
+
         if (isSelected) {
           drawRectOnSelected = () => {
             ctx.save();
@@ -264,19 +288,19 @@ export class ChromeSliceTrack extends Track<Config, Data> {
             ctx.scale(INNER_CHEVRON_SCALE, INNER_CHEVRON_SCALE);
             ctx.fillStyle = cachedHsluvToHex(hue, 100, 10);
 
-            this.drawChevron(ctx);
+            this.drawChevron(ctx, instant);
             ctx.restore();
 
             // Draw inner chevron as interior
             ctx.fillStyle = color;
-            this.drawChevron(ctx);
+            this.drawChevron(ctx, instant);
 
             ctx.restore();
           };
         } else {
           ctx.save();
           ctx.translate(rect.left, rect.top);
-          this.drawChevron(ctx);
+          this.drawChevron(ctx, instant);
           ctx.restore();
         }
         continue;
@@ -325,7 +349,7 @@ export class ChromeSliceTrack extends Track<Config, Data> {
     drawRectOnSelected();
   }
 
-  drawChevron(ctx: CanvasRenderingContext2D) {
+  drawChevron(ctx: CanvasRenderingContext2D, _instant?: Instant) {
     // Draw a chevron at a fixed location and size. Should be used with
     // ctx.translate and ctx.scale to alter location and size.
     ctx.beginPath();

--- a/ui/src/tracks/chrome_slices/index.ts
+++ b/ui/src/tracks/chrome_slices/index.ts
@@ -59,13 +59,9 @@ export interface Data extends TrackData {
 // Like a Slice, but only of the instantaneous kind and
 // only enough information to render it in the track
 export interface Instant {
-  id: number;
-  start: bigint;
-  depth: number;
   title: string;
   color: string;
   tmAscent: number;
-  tmWidth: number;
 }
 
 export class ChromeSliceTrackController extends TrackController<Config, Data> {
@@ -268,13 +264,9 @@ export class ChromeSliceTrack extends Track<Config, Data> {
       // Then B, C, D and back to A:
       if (isInstant) {
         const instant: Instant = {
-          id: sliceId,
-          depth,
           title,
-          start: tStart,
           color,
           tmAscent: charAscent,
-          tmWidth: charWidth,
         };
 
         if (isSelected) {

--- a/ui/src/tracks/chrome_slices/index.ts
+++ b/ui/src/tracks/chrome_slices/index.ts
@@ -341,6 +341,14 @@ export class ChromeSliceTrack extends Track<Config, Data> {
     drawRectOnSelected();
   }
 
+  // Draw a chevron for the current intantaneous slice in the track.
+  // The optional |Instant| provides additional hints that may be
+  // useful in rendering the slice.
+  //
+  // Precondition: the calling context must first |save| the |ctx| because this
+  //   method is free to change fill style, transform, and other properties of
+  //   the context. And the caller must |restore| the |ctx| on return from this
+  //   method to clear any such changes.
   drawChevron(ctx: CanvasRenderingContext2D, _instant?: Instant) {
     // Draw a chevron at a fixed location and size. Should be used with
     // ctx.translate and ctx.scale to alter location and size.


### PR DESCRIPTION
In the buffer tracks for SurfaceFlinger events, clearly show the kind of event by rendering the event slice not as a chevron but as

- a diamond shape with
- the initial letter of the event name as a stamp indicating at a glance the type of buffer event
