### PR TITLE
Fix scrolling to tracks in nested groups

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -368,6 +368,7 @@ $bottom-tab-padding: 10px;
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-rows: 1fr 0;
+  scroll-margin-top: 40px;
 
   &::after {
     display: block;

--- a/ui/src/frontend/frontend_local_state.ts
+++ b/ui/src/frontend/frontend_local_state.ts
@@ -160,6 +160,7 @@ export class FrontendLocalState {
   visibleTracks = new Set<string>();
   prevVisibleTracks = new Set<string>();
   scrollToTrackId?: string|number;
+  expandTrackGroupIds = new Set<string>();
   httpRpcState: HttpRpcState = {connected: false};
   newVersionAvailable = false;
   detailsFullScreenSelectors = ['.pan-and-zoom-content'];

--- a/ui/src/frontend/scroll_helper.ts
+++ b/ui/src/frontend/scroll_helper.ts
@@ -121,63 +121,104 @@ export function verticalScrollToTrack(
     return;
   }
 
-  // Track groups containing the track to be revealed, in order from top
-  // down, represented either as the rendered HTML element or, if not
-  // rendered because an ancestor group is collapsed, its UUID
-  const trackGroupsTopDown: (Element|string)[] = [];
+  // At this point, the requested track to reveal is not rendered because it
+  // is contained by some group that is collapsed, at some level of nesting.
+  // So we will either be expanding groups to reveal the track and scroll to
+  // it, or we will simply reveal the closest containing group that we can.
+  // That starts with finding what is the chain of containing groups' UUIDs.
   const containingIds = getContainingTrackIds(globals.state, trackIdString);
   if (!containingIds || !containingIds.length) {
     console.error(`Can't scroll, track (${trackIdString}) not found.`);
     return;
   }
 
-  for (const trackGroupId of containingIds) {
-    const group = document.querySelector('#track_' + trackGroupId);
-
-    if (group) {
-      trackGroupsTopDown.push(group);
-    } else {
-      // Some containing group is collapsed, so this one is not rendered
-      trackGroupsTopDown.push(trackGroupId);
-    }
-  }
+  // Track groups containing the track to be revealed, in order from top
+  // down, represented either as the rendered HTML element or, if not
+  // rendered because an ancestor group is collapsed, its UUID
+  const trackGroupsTopDown = getTrackGroupsTopDown(containingIds);
 
   // The requested track is inside a closed track group. Either open the track
   // group and scroll to the track or just scroll to deepest nested track group
   // that has been rendered.
   if (openGroup) {
-    // After the track exists in the dom, it will be scrolled to.
-    globals.frontendLocalState.scrollToTrackId = trackId;
-    for (let i = 1; i < trackGroupsTopDown.length; i++) {
-      const trackGroup = trackGroupsTopDown[i];
-      if (typeof trackGroup === 'string') {
-        // Expand its parent
-        if (typeof trackGroupsTopDown[i - 1] !== 'string') {
-          const trackGroupId = containingIds[i - 1];
-          globals.dispatch(Actions.toggleTrackGroupCollapsed({trackGroupId}));
-        }
+    expandGroupsToRevealTrack(trackIdString, containingIds, trackGroupsTopDown);
+  } else {
+    scrollToDeepestTrackGroup(trackGroupsTopDown);
+  }
+}
 
-        // And mark all the rest for expansion when they are created
-        globals.frontendLocalState.expandTrackGroupIds.add(trackGroup);
-      } else if (i === (trackGroupsTopDown.length - 1)) {
-        // Need to expand the bottommost group to create the track to reveal
-        const trackGroupId = containingIds[i];
-        globals.dispatch(Actions.toggleTrackGroupCollapsed({trackGroupId}));
-      }
+// Get the rendered track groups in the given hierarchical chain,
+// in order from topmost to deepest, as many as are rendered by
+// their own container having been expanded in the UI.
+// These are represented in the resulting array by |Element|.
+// All further nested track groups that are not rendered are
+// represented in the resulting array by their UUIDs.
+// down, represented either as the rendered HTML element or, if not
+// rendered because an ancestor group is collapsed, its UUID.
+function getTrackGroupsTopDown(groupIds: string[]): (Element|string)[] {
+  const result: (Element|string)[] = [];
+
+  for (const trackGroupId of groupIds) {
+    const group = document.querySelector('#track_' + trackGroupId);
+
+    if (group) {
+      result.push(group);
+    } else {
+      // Some containing group is collapsed, so this one is not rendered
+      result.push(trackGroupId);
     }
-    return;
   }
 
-  // Find the deepest rendered group and scroll to it
-  for (let i = trackGroupsTopDown.length - 1; i >= 0; i--) {
-    const trackGroup = trackGroupsTopDown[i];
+  return result;
+}
+
+// Expand whatever groups in the |trackGroupsTopDown| that are
+// collapsed as necessary to reveal and scroll to the track
+// identified by the given |trackId|. Each element of the
+// |trackGroupTopDown| is identified by the corresponding UUID
+// in the |containingGroupIds| array. As there is potentially
+// some tail of the former that are UUIDs representing unrendered
+// groups (because their container is collapsed), there may be
+// overlap in these arrays.
+function expandGroupsToRevealTrack(trackId: string,
+    containingGroupIds: string[],
+    trackGroupsTopDown: (Element|string)[]): void {
+  // After the track exists in the DOM, it will be scrolled to.
+  globals.frontendLocalState.scrollToTrackId = trackId;
+
+  trackGroupsTopDown.forEach(
+      (trackGroup: Element|string, i: number) => {
+    // It should not happen that the topmost group is not rendered
+    // because it has no real parent group that could be collapsed.
+    if ((typeof trackGroup === 'string') && (i > 0)) {
+      // Expand its parent
+      if (typeof trackGroupsTopDown[i - 1] !== 'string') {
+        const trackGroupId = containingGroupIds[i - 1];
+        globals.dispatch(Actions.toggleTrackGroupCollapsed({trackGroupId}));
+      }
+
+      // And mark all the rest for expansion when they are created
+      globals.frontendLocalState.expandTrackGroupIds.add(trackGroup);
+    } else if (i === (trackGroupsTopDown.length - 1)) {
+      // Need to expand the bottommost group to create the track to reveal
+      const trackGroupId = containingGroupIds[i];
+      globals.dispatch(Actions.toggleTrackGroupCollapsed({trackGroupId}));
+    }
+  });
+}
+
+// Find the deepest track group in the |trackGroupsTopDown| array
+// that is a rendered |Element| and scroll to it. If none of the
+// groups is rendered, then no scroll will occur.
+function scrollToDeepestTrackGroup(
+    trackGroupsTopDown: (Element|string)[]): void {
+  for (const trackGroup of trackGroupsTopDown.slice().reverse()) {
     if (typeof trackGroup !== 'string') {
       trackGroup.scrollIntoView({behavior: 'smooth', block: 'nearest'});
       break;
     }
   }
 }
-
 
 // Scroll vertically and horizontally to reach track (|trackId|) at |ts|.
 export function scrollToTrackAndTs(

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -194,6 +194,16 @@ export class TrackGroupPanel extends Panel<Attrs> {
 
   oncreate(vnode: m.CVnodeDOM<Attrs>) {
     this.onupdate(vnode);
+    const trackGroupId = vnode.attrs.trackGroupId;
+    if (globals.frontendLocalState.expandTrackGroupIds.has(trackGroupId)) {
+      // An attempt to scroll to reveal a track that is contained within
+      // this group was waiting for it to be created by expansion of an
+      // ancestor, so make sure that it is expanded now that it exists
+      if (this.trackGroupState.collapsed) {
+        globals.dispatch(Actions.toggleTrackGroupCollapsed({trackGroupId}));
+      }
+      globals.frontendLocalState.expandTrackGroupIds.delete(trackGroupId);
+    }
   }
 
   onupdate({dom}: m.CVnodeDOM<Attrs>) {


### PR DESCRIPTION
The introduction of nested groups means that, in addition to tracks, now sometimes groups in the hierarchy will not be rendered yet when we want to reveal a track. So add a similar mechanism in the frontend local state to notify a group upon its rendering that it needs to be expanded because the UI is trying to reveal a track within it.
