### PR TITLE
Extensibility of async slice coloring

### DIFF
--- a/ui/src/base/string_utils.ts
+++ b/ui/src/base/string_utils.ts
@@ -115,3 +115,20 @@ export function binaryDecode(str: string): Uint8Array {
 export function sqliteString(str: string): string {
   return `'${str.replace(/'/g, '\'\'')}'`;
 }
+
+// Obtain a function that interns strings in the given |store|.
+// The return results are indices into the |store|'s |strings|.
+// The result of interning the same string is always the same index.
+export function stringInterner(store: { strings: string[] }):
+    (str: string) => number {
+  const stringIndexes = new Map<string, number>();
+
+  return (str: string) => {
+    let idx = stringIndexes.get(str);
+    if (idx !== undefined) return idx;
+    idx = store.strings.length;
+    store.strings.push(str);
+    stringIndexes.set(str, idx);
+    return idx;
+  };
+}

--- a/ui/src/base/string_utils_unittest.ts
+++ b/ui/src/base/string_utils_unittest.ts
@@ -18,6 +18,7 @@ import {
   binaryDecode,
   binaryEncode,
   sqliteString,
+  stringInterner,
   utf8Decode,
   utf8Encode,
 } from './string_utils';
@@ -79,4 +80,15 @@ test('string_utils.sqliteString', () => {
   expect(sqliteString('that\'s it')).toEqual('\'that\'\'s it\'');
   expect(sqliteString('no quotes')).toEqual('\'no quotes\'');
   expect(sqliteString(`foo ' bar '`)).toEqual(`'foo '' bar '''`);
+});
+
+test('string_utils.stringInterner', () => {
+  const strings: string[] = [];
+  const interner = stringInterner({strings});
+
+  expect(interner('foo')).toEqual(0);
+  expect(interner('bar')).toEqual(1);
+  expect(interner('')).toEqual(2);
+  expect(interner('bar')).toEqual(1);
+  expect(strings).toEqual(['foo', 'bar', '']);
 });

--- a/ui/src/tracks/chrome_slices/index.ts
+++ b/ui/src/tracks/chrome_slices/index.ts
@@ -222,7 +222,7 @@ export class ChromeSliceTrack extends Track<Config, Data> {
       const isInstant = data.isInstant[i];
       const isIncomplete = data.isIncomplete[i];
       const title = data.strings[titleId];
-      const colorOverride = data.colors && data.strings[data.colors[i]];
+      const colorOverride = this.getColorOverride(data, i);
       if (isIncomplete) {  // incomplete slice
         // TODO(stevegolton): This isn't exactly equivalent, ideally we should
         // choose tEnd once we've conerted to screen space coords.
@@ -359,6 +359,12 @@ export class ChromeSliceTrack extends Track<Config, Data> {
     ctx.lineTo(-HALF_CHEVRON_WIDTH_PX, SLICE_HEIGHT);
     ctx.lineTo(0, 0);
     ctx.fill();
+  }
+
+  // Get a color to override the default paint color for the indicated slice.
+  // By default, an override is sought in the array if |colors| in the |data|.
+  getColorOverride(data: Data, sliceIndex: number): string|undefined {
+    return data.colors ? data.strings[data.colors[sliceIndex]] : undefined;
   }
 
   getSliceIndex({x, y}: {x: number, y: number}): number|void {


### PR DESCRIPTION
Minor changes to support extensibility of the coloring of async slices by plug-ins that reuse the AsyncSliceTrack implementation:

- factor out string interning in the data store into the string utils
- correct the missing colors property in the controller's view of the Data to align with the track implementation's Data interface
