### PR TITLE
Don't look for track selections under the pinned tracks

### DIFF
--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -140,11 +140,21 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
 
     // The Y value is given from the top of the pan and zoom region, we want it
     // from the top of the panel container. The parent offset corrects that.
+    const startY = globals.frontendLocalState.areaY.start + TOPBAR_HEIGHT;
+    const endY = globals.frontendLocalState.areaY.end + TOPBAR_HEIGHT;
+
+    // Moreover, if the selection is scrolled up under an overlying panel
+    // (such as the pinned tracks panel) then don't handle it at all.
+    const visibleTop = this.panelContainerTop + this.scrollTop;
+    if (startY < visibleTop || endY < visibleTop) {
+      return;
+    }
+
     const panels = this.getPanelsInRegion(
         visibleTimeScale.tpTimeToPx(area.start),
         visibleTimeScale.tpTimeToPx(area.end),
-        globals.frontendLocalState.areaY.start + TOPBAR_HEIGHT,
-        globals.frontendLocalState.areaY.end + TOPBAR_HEIGHT);
+        startY,
+        endY);
     // Get the track ids from the panels.
     const tracks = [];
     for (const panel of panels) {


### PR DESCRIPTION
Where the scrolling track panel is scrolled up under the pinned tracks, don't attempt to find tracks selected by the drawing out of an area selection area because whatever that result is, it will replace the track selection from the pinned tracks, themselves.
