### PR TITLE
Fix area-selection track selection toggle tooltips

### DIFF
--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -147,8 +147,8 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
                 },
                 i: isSelected(attrs.trackState.id) ? CHECKBOX : BLANK_CHECKBOX,
                 tooltip: isSelected(attrs.trackState.id) ?
-                    'Remove track' :
-                    'Add track to selection',
+                    'Exclude track from area selection' :
+                    'Include track in area selection',
                 showButton: true,
               }) :
               ''));


### PR DESCRIPTION
There is a separate button for removing a track from the UI which has a tooltip "Remove Track". This is also used for the tooltip on the area selection toggle. Change the state-dependent tooltips for the latter to indicate clearly that the toggle includes the track in or excludes it from the area selection.
