### PR TITLE
Close the error dialog if it is opened before setting error handler

### DIFF
--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -21,7 +21,7 @@ import {TraceUrlSource} from '../common/state';
 import {saveTrace} from '../common/upload_utils';
 
 import {globals} from './globals';
-import {showModal} from './modal';
+import {ModalDefinition, showModal as basicShowModal} from './modal';
 import {isShareable} from './trace_attrs';
 
 // Never show more than one dialog per minute.
@@ -31,6 +31,17 @@ let timeLastReport = 0;
 // Keeps the last ERR_QUEUE_MAX_LEN errors while the dialog is throttled.
 const queuedErrors = new Array<string>();
 const ERR_QUEUE_MAX_LEN = 10;
+
+export const ERROR_MODAL_KIND = 'error';
+
+// Override the standard |showModal| function to set the
+// error |kind| unless the |attrs| happen to have a |kind|.
+function showModal(attrs: ModalDefinition): Promise<void> {
+  if (attrs.kind === undefined) {
+    attrs.kind = ERROR_MODAL_KIND;
+  }
+  return basicShowModal(attrs);
+}
 
 export function showErrorDialog(errLog: string) {
   // Force showing the dialog by resetting the last report time

--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -45,7 +45,8 @@ import {RafScheduler} from './raf_scheduler';
 import {Router} from './router';
 import {ServiceWorkerController} from './service_worker_controller';
 import {PxSpan, TimeScale} from './time_scale';
-import {maybeShowErrorDialog} from './error_dialog';
+import {ERROR_MODAL_KIND, maybeShowErrorDialog} from './error_dialog';
+import {fullscreenModalContainer} from './modal';
 
 type Dispatch = (action: DeferredAction) => void;
 type TrackDataStore = Map<string, {}>;
@@ -669,6 +670,13 @@ class Globals {
   }
 
   set errorHandler(errorHandler: ErrorHandler) {
+    if (this._errorHandler === maybeShowErrorDialog) {
+      // If we were showing an error dialog, close it because there's
+      // a new error-handling sheriff in town.
+      if (fullscreenModalContainer.kind === ERROR_MODAL_KIND) {
+        fullscreenModalContainer.close();
+      }
+    }
     this._errorHandler = errorHandler;
   }
 

--- a/ui/src/frontend/modal.ts
+++ b/ui/src/frontend/modal.ts
@@ -65,6 +65,8 @@ export interface ModalDefinition {
   buttons?: Button[];
   close?: boolean;
   onClose?: () => void;
+  // Optional indication of the model kind/purpose.
+  kind?: string;
 }
 
 export interface Button {
@@ -277,6 +279,16 @@ export class ModalContainer {
   close() {
     this.closeGeneration = this.generation;
     globals.rafScheduler.scheduleFullRedraw();
+  }
+
+  // Query the kind of |Modal| that is open, if it is open and it
+  // has a |kind| in its |ModalDefinition|.
+  get kind(): string|undefined {
+    if (this.generation == this.closeGeneration || this.attrs?.close) {
+      // Closed
+      return undefined;
+    }
+    return this.attrs?.kind;
   }
 }
 


### PR DESCRIPTION
A custom error handler may be set by an embedding application via the globals. However, an error may have already been trapped and presented after Perfetto was loaded but before it was rendered. In this case, the dialog was already created and ready to present when Perfetto was rendered, after the embedding application set a different error handler.

Now when the error handler is set, any pending error dialog is closed or prevented from being shown.
