### PR TITLE
Don't update overview timeline panel when invisible

### DIFF
--- a/ui/src/frontend/overview_timeline_panel.ts
+++ b/ui/src/frontend/overview_timeline_panel.ts
@@ -50,9 +50,13 @@ export class OverviewTimelinePanel extends Panel {
   // https://github.com/Microsoft/TypeScript/issues/1373
   onupdate({dom}: m.CVnodeDOM) {
     const newWidth = dom.getBoundingClientRect().width;
-    if (newWidth > 0) { // It may be zero when temporarily not visible
-      this.width = newWidth;
+    if (newWidth <= 0) {
+      // Client rect width may be zero when temporarily not visible.
+      // So don't update now and we'll pick this up later.
+      return;
     }
+
+    this.width = newWidth;
     this.traceTime = globals.stateTraceTimeTP();
     const traceTime = globals.stateTraceTime();
     const pxSpan = new PxSpan(TRACK_SHELL_WIDTH, this.width);


### PR DESCRIPTION
In the context of an embedding application, the Perfetto UI sometimes is not visible and the client rect of the overview timeline panel can be zero. In that case, creating the PxSpan fails its assertion. Fix that by just not updating until eventually the client rect is available.

Please do not submit a Pull Request via GitHub.
Our project makes use of Gerrit for patch submission and review.

For more details please see
https://perfetto.dev/docs/contributing/getting-started

