### PR TITLE
Highlight vsyncs in columns across all tracks

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -31,6 +31,7 @@
   --alt-background-color: #d3d3d3;
   --overview-background-color: #ffffff;
   --track-highlight-background: #ffe263;
+  --track-vsync-background: #e7e7e7;
 }
 
 @mixin transition($time: 0.1s) {

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -120,6 +120,7 @@ import {
 import {TrackControllerArgs, trackControllerRegistry} from './track_controller';
 import {decideTracks} from './track_decider';
 import {VisualisedArgController} from './visualised_args_controller';
+import {VsyncController} from './vsync_controller';
 
 type States = 'init' | 'loading_trace' | 'ready';
 
@@ -327,6 +328,10 @@ export class TraceController extends Controller<States> {
         childControllers.push(
           Child('traceError', TraceErrorController, {engine}));
         childControllers.push(Child('metrics', MetricsController, {engine}));
+
+        // Vsync data from SurfaceFlinger's VSYNC-app counter, if available
+        childControllers.push(
+          Child('vsync', VsyncController, {engine, app: globals}));
 
         return childControllers;
 

--- a/ui/src/controller/vsync_controller.ts
+++ b/ui/src/controller/vsync_controller.ts
@@ -1,0 +1,120 @@
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {assertExists} from '../base/logging';
+import {Engine} from '../common/engine';
+import {LONG, NUM} from '../common/query_result';
+import {Span} from '../common/time';
+import {globals} from '../frontend/globals';
+import {publishVsyncData} from '../frontend/publish';
+import {Controller} from './controller';
+
+export interface VsyncControllerArgs {
+  engine: Engine;
+}
+
+export class VsyncController extends Controller<'init'|'ready'> {
+  private engine: Engine;
+  private trackId?: number;
+  private timeSpan?: Span<bigint>;
+
+  constructor(args: VsyncControllerArgs) {
+    super('init');
+
+    this.engine = args.engine;
+  }
+
+  onDestroy() {
+    publishVsyncData({});
+  }
+
+  run() {
+    switch (this.state) {
+      case 'init':
+        this.getVsyncTrack().then((trackId) => this.trackId = trackId);
+        this.setState('ready');
+        break;
+      case 'ready':
+        if (this.trackId === undefined) {
+          // Still waiting for the track ID
+          return;
+        }
+        const visibleTimeSpan = globals.stateVisibleTime();
+        if (this.timeSpan === undefined ||
+            !this.timeSpan.equals(visibleTimeSpan)) {
+          this.timeSpan = visibleTimeSpan;
+          this.getVsyncData(this.trackId, this.timeSpan);
+        }
+        break;
+      default:
+        throw new Error(`Unexpected state ${this.state}`);
+    }
+  }
+
+  async getVsyncTrack(): Promise<number|undefined> {
+    // Determine the track ID of the SurfaceFlinger VSYNC-app counter, if
+    // it exists.
+    const result = await this.engine.query(`
+      select process_counter_track.id as trackId
+      from process
+        join process_counter_track using (upid)
+      where process.name like '%/surfaceflinger' and
+        process_counter_track.name='VSYNC-app'
+      limit 1;
+    `);
+    if (result.numRows() < 1) {
+      return undefined;
+    }
+
+    const trackId = result.firstRow({'trackId': NUM}).trackId;
+    return trackId;
+  }
+
+  async getVsyncData(trackId: number, timeSpan: Span<bigint>) {
+    // Get at least two changes of the counter in the currently
+    // visible timespan of the trace
+    const result = await this.engine.query(`
+      select ts, value from (
+        select row_number() over (order by ts) as rn, ts, value
+        from counter
+        where track_id = ${trackId} and ts >= ${timeSpan.start}
+        order by ts)
+      where rn <= 2 or ts <= ${timeSpan.end};
+    `);
+
+    const toggleTs: bigint[] = [];
+    let initiallyOn: boolean|undefined;
+    let lastWasOn = false;
+
+    const row = result.iter({ts: LONG, value: NUM});
+    for (; row.valid(); row.next()) {
+      const on = (row.value === 1);
+      if (initiallyOn === undefined) {
+        initiallyOn = !on;
+        lastWasOn = initiallyOn;
+      }
+      if (on !== lastWasOn) {
+        lastWasOn = on;
+        toggleTs.push(row.ts);
+      } // Otherwise, it didn't toggle
+    }
+
+    if (toggleTs.length === 0) {
+      publishVsyncData({});
+    } else {
+      initiallyOn = assertExists(initiallyOn);
+      publishVsyncData({initiallyOn, toggleTs});
+    }
+  }
+}

--- a/ui/src/frontend/frontend_local_state.ts
+++ b/ui/src/frontend/frontend_local_state.ts
@@ -178,6 +178,7 @@ export class FrontendLocalState {
   };
 
   private _selectedArea?: Area;
+  private _vsyncHighlight = false;
 
   // TODO: there is some redundancy in the fact that both |visibleWindowTime|
   // and a |timeScale| have a notion of time range. That should live in one
@@ -263,6 +264,17 @@ export class FrontendLocalState {
 
   get selectedArea(): Area|undefined {
     return this._selectedArea;
+  }
+
+  // Toggle whether to show the vsync highlight across the tracks (if available)
+  toggleVsyncHighlight() {
+    this._vsyncHighlight = !this._vsyncHighlight;
+    globals.rafScheduler.scheduleRedraw();
+  }
+
+  // Whether to show the vsync highlight across the tracks (if available)
+  get vsyncHighlight(): boolean {
+    return this._vsyncHighlight;
   }
 
   private ratelimitedUpdateVisible = ratelimit(() => {

--- a/ui/src/frontend/help_modal.ts
+++ b/ui/src/frontend/help_modal.ts
@@ -168,6 +168,9 @@ class KeyMappingsHelp implements m.ClassComponent {
             m('tr',
               m('td', keycap(ctrlOrCmd), ' + ', keycap('a')),
               m('td', 'Select all')),
+            m('tr',
+              m('td', keycap('v')),
+              m('td', 'Show vsync points in columns across all tracks')),
             ...sidebarInstructions,
             m('tr', m('td', keycap('?')), m('td', 'Show help')),
             ));

--- a/ui/src/frontend/help_modal.ts
+++ b/ui/src/frontend/help_modal.ts
@@ -170,7 +170,7 @@ class KeyMappingsHelp implements m.ClassComponent {
               m('td', 'Select all')),
             m('tr',
               m('td', keycap('v')),
-              m('td', 'Show vsync points in columns across all tracks')),
+              m('td', 'Highlight VSyncs')),
             ...sidebarInstructions,
             m('tr', m('td', keycap('?')), m('td', 'Show help')),
             ));

--- a/ui/src/frontend/keyboard_event_handler.ts
+++ b/ui/src/frontend/keyboard_event_handler.ts
@@ -119,6 +119,10 @@ export function handleKey(e: KeyboardEvent, down: boolean): boolean {
     moveByFocusedFlow('Backward');
     return true;
   }
+  if (down && 'v' === key && noModifiers) {
+    globals.frontendLocalState.toggleVsyncHighlight();
+    return true;
+  }
   return false;
 }
 

--- a/ui/src/frontend/publish.ts
+++ b/ui/src/frontend/publish.ts
@@ -36,6 +36,7 @@ import {
   SliceDetails,
   ThreadDesc,
   ThreadStateDetails,
+  VsyncData,
 } from './globals';
 import {findCurrentSelection} from './keyboard_event_handler';
 
@@ -206,5 +207,13 @@ export function publishConnectedFlows(connectedFlows: Flow[]) {
 
 export function publishFtracePanelData(data: FtracePanelData) {
   globals.ftracePanelData = data;
+  globals.publishRedraw();
+}
+
+export function publishVsyncData(data: Partial<VsyncData>) {
+  globals.vsyncData = {
+    initiallyOn: !!data.initiallyOn,
+    toggleTs: data.toggleTs ?? [],
+  };
   globals.publishRedraw();
 }

--- a/ui/src/frontend/track.ts
+++ b/ui/src/frontend/track.ts
@@ -23,6 +23,7 @@ import {TrackData} from '../common/track_data';
 import {checkerboard} from './checkerboard';
 import {globals} from './globals';
 import {TrackButtonAttrs} from './track_panel';
+import {getActiveVsyncData, renderVsyncColumns} from './vsync_helper';
 
 // Args passed to the track constructors when creating a new track.
 export interface NewTrackArgs {
@@ -138,6 +139,13 @@ export abstract class Track<Config = {}, Data extends TrackData = TrackData> {
           Math.ceil(visibleTimeScale.hpTimeToPx(visibleWindowTime.end));
       checkerboard(ctx, this.getHeight(), startPx, endPx);
     } else {
+      // If we have vsync data, render columns under the track
+      const vsync = getActiveVsyncData();
+      if (vsync) {
+        ctx.save();
+        renderVsyncColumns(ctx, this.getHeight(), vsync);
+        ctx.restore();
+      }
       this.renderCanvas(ctx);
     }
   }

--- a/ui/src/frontend/track.ts
+++ b/ui/src/frontend/track.ts
@@ -23,7 +23,6 @@ import {TrackData} from '../common/track_data';
 import {checkerboard} from './checkerboard';
 import {globals} from './globals';
 import {TrackButtonAttrs} from './track_panel';
-import {getActiveVsyncData, renderVsyncColumns} from './vsync_helper';
 
 // Args passed to the track constructors when creating a new track.
 export interface NewTrackArgs {
@@ -139,13 +138,6 @@ export abstract class Track<Config = {}, Data extends TrackData = TrackData> {
           Math.ceil(visibleTimeScale.hpTimeToPx(visibleWindowTime.end));
       checkerboard(ctx, this.getHeight(), startPx, endPx);
     } else {
-      // If we have vsync data, render columns under the track
-      const vsync = getActiveVsyncData();
-      if (vsync) {
-        ctx.save();
-        renderVsyncColumns(ctx, this.getHeight(), vsync);
-        ctx.restore();
-      }
       this.renderCanvas(ctx);
     }
   }

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -39,6 +39,7 @@ import {trackRegistry} from './track_registry';
 import {
   drawVerticalLineAtTime,
 } from './vertical_line_helper';
+import {getActiveVsyncData, renderVsyncColumns} from './vsync_helper';
 
 interface Attrs {
   trackGroupId: string;
@@ -300,6 +301,15 @@ export class TrackGroupPanel extends Panel<Attrs> {
     ctx.fillRect(0, 0, size.width, size.height);
 
     if (!collapsed) return;
+
+    // If we have vsync data, render columns under the track group
+    const vsync = getActiveVsyncData();
+    if (vsync) {
+      ctx.save();
+      ctx.translate(this.shellWidth, 0);
+      renderVsyncColumns(ctx, size.height, vsync);
+      ctx.restore();
+    }
 
     this.highlightIfTrackSelected(ctx, size);
 

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -31,6 +31,7 @@ import {trackRegistry} from './track_registry';
 import {
   drawVerticalLineAtTime,
 } from './vertical_line_helper';
+import {getActiveVsyncData, renderVsyncColumns} from './vsync_helper';
 import {SCROLLING_TRACK_GROUP, getContainingTrackIds} from '../common/state';
 
 function getTitleSize(title: string): string|undefined {
@@ -415,6 +416,16 @@ export class TrackPanel extends Panel<TrackPanelAttrs> {
 
   renderCanvas(ctx: CanvasRenderingContext2D, size: PanelSize) {
     ctx.save();
+
+    // If we have vsync data, render columns under the track and
+    // under the grid lines painted next
+    const vsync = getActiveVsyncData();
+    if (vsync) {
+      ctx.save();
+      ctx.translate(TRACK_SHELL_WIDTH, 0);
+      renderVsyncColumns(ctx, size.height, vsync);
+      ctx.restore();
+    }
 
     drawGridLines(
         ctx,

--- a/ui/src/frontend/vsync_helper.ts
+++ b/ui/src/frontend/vsync_helper.ts
@@ -1,0 +1,70 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {getCssStr} from './css_constants';
+import {globals, VsyncData} from './globals';
+
+// Get the vsync data that the user has opted to highlight under the tracks.
+export function getActiveVsyncData(): VsyncData|undefined {
+  return globals.frontendLocalState.vsyncHighlight ?
+    globals.vsyncData :
+    undefined;
+}
+
+// Render columns where the SurfaceFlinger VSYNC-app counter is on
+// in the background of a track or track group of the given |height|,
+// as indicated by the |vsync| data.
+//
+// Preconditions:
+//  - the rendering |ctx| is saved, if necessary, because
+//    this function reconfigures it
+//  - the rendering |ctx| is translated to put the origin at the beginning
+//    edge of the track or track group
+export function renderVsyncColumns(ctx: CanvasRenderingContext2D,
+    height: number, vsync: VsyncData) {
+  const vsyncBackground = getCssStr('--track-vsync-background') ?? '#e7e7e7';
+  const {visibleWindowTime, visibleTimeScale} = globals.frontendLocalState;
+  const startPx =
+    Math.floor(visibleTimeScale.hpTimeToPx(visibleWindowTime.start));
+  const endPx =
+    Math.floor(visibleTimeScale.hpTimeToPx(visibleWindowTime.end));
+  const startTs = visibleWindowTime.start.toTPTime();
+  const endTs = visibleWindowTime.end.toTPTime();
+
+  ctx.fillStyle = vsyncBackground;
+
+  let fill = vsync.initiallyOn;
+  let lastX = startPx;
+  for (const ts of vsync.toggleTs) {
+    if (ts < startTs) {
+      fill = !fill;
+      continue;
+    }
+    const x = visibleTimeScale.tpTimeToPx(ts);
+    if (fill) {
+      ctx.fillRect(lastX, 0, x - lastX, height);
+    }
+    if (ts > endTs) {
+      break;
+    }
+    lastX = x;
+    fill = !fill;
+  }
+
+  // Do we need to fill out to the end?
+  if (fill && lastX > startPx && lastX < endPx) {
+    ctx.fillRect(lastX, 0, endPx - lastX, height);
+  }
+}
+


### PR DESCRIPTION
For traces that have the VSYNC-app counter track in the SurfaceFlinger, support a 'v' key toggle to show the alignment of the vsyncs with other content in the tracks.
