### PR TITLE
Non-GPU Counters in GPU Counters

### DIFF
--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -103,7 +103,7 @@ const ENTITY_RESIDENCY_REGEX = new RegExp('^Entity residency:');
 const ENTITY_RESIDENCY_GROUP = 'Entity residency';
 const BATTERY_TRACK_REGEX = new RegExp('^(batt|power)\\..*$');
 const BATTERY_TRACK_GROUP = 'Battery';
-const globalCounters = ['Buffers', 'Cached', 'MemFree', 'MemTotal', 'SwapCached'];
+const MEMORY_USAGE_COUNTERS = ['Buffers', 'Cached', 'MemFree', 'MemTotal', 'SwapCached'];
 // Sets the default 'scale' for counter tracks. If the regex matches
 // then the paired mode is used. Entries are in priority order so the
 // first match wins.
@@ -417,17 +417,16 @@ class TrackDecider {
   }
 
   async groupCounterTracks(): Promise<void> {
-    for (let index = 0; index < this.tracksToAdd.length; index++) {
-      const track = this.tracksToAdd[index];
+    for (const track of this.tracksToAdd) {
       if (track.kind !== COUNTER_TRACK_KIND ||
         (track.trackGroup && track.trackGroup !== SCROLLING_TRACK_GROUP)) {
         continue;
       }
-      if (globalCounters.includes(track.name)) {
-        this.tracksToAdd[index].trackGroup = this.lazyTrackGroup('Memory Usage')();
+      if (MEMORY_USAGE_COUNTERS.includes(track.name)) {
+        track.trackGroup = this.lazyTrackGroup('Memory Usage')();
         continue;
       }
-      this.tracksToAdd[index].trackGroup = this.lazyTrackGroup('GPU Counters', {collapsed: false, parentGroup: this.gpuGroup()})();
+      track.trackGroup = this.lazyTrackGroup('GPU Counters', {collapsed: false, parentGroup: this.gpuGroup()})();
     }
   }
   async addScrollJankTracks(engine: Engine): Promise<void> {

--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -422,7 +422,7 @@ class TrackDecider {
         continue;
       }
       // Check if track is a GPU counter
-      const result = await this.engine.query('select description from gpu_counter_track where name = "' + track.name + '"');
+      const result = await this.engine.query(`select description from gpu_counter_track where name = "${track.name}"`);
       if (result.numRows() > 0) {
         track.trackGroup = this.lazyTrackGroup('GPU Counters', {collapsed: false, parentGroup: this.gpuGroup()})();
       } else {

--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -420,8 +420,11 @@ class TrackDecider {
     for (let index = 0; index < this.tracksToAdd.length; index++) {
       const track = this.tracksToAdd[index];
       if (track.kind !== COUNTER_TRACK_KIND ||
-        (track.trackGroup && track.trackGroup !== SCROLLING_TRACK_GROUP) ||
-        globalCounters.includes(track.name)) {
+        (track.trackGroup && track.trackGroup !== SCROLLING_TRACK_GROUP)) {
+        continue;
+      }
+      if (globalCounters.includes(track.name)) {
+        this.tracksToAdd[index].trackGroup = this.lazyTrackGroup('Memory Usage')();
         continue;
       }
       this.tracksToAdd[index].trackGroup = this.lazyTrackGroup('GPU Counters', {collapsed: false, parentGroup: this.gpuGroup()})();

--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -416,14 +416,17 @@ class TrackDecider {
   }
 
   async groupCounterTracks(): Promise<void> {
+    const counterTracks : string[] = [];
+    const iter = (await this.engine.query(`select name from gpu_counter_track`)).iter({name: STR});
+    for (; iter.valid(); iter.next()) {
+      counterTracks.push(iter.name);
+    }
     for (const track of this.tracksToAdd) {
       if (track.kind !== COUNTER_TRACK_KIND ||
         (track.trackGroup && track.trackGroup !== SCROLLING_TRACK_GROUP)) {
         continue;
       }
-      // Check if track is a GPU counter
-      const result = await this.engine.query(`select description from gpu_counter_track where name = "${track.name}"`);
-      if (result.numRows() > 0) {
+      if (counterTracks.includes(track.name)) {
         track.trackGroup = this.lazyTrackGroup('GPU Counters', {collapsed: false, parentGroup: this.gpuGroup()})();
       } else {
         track.trackGroup = this.lazyTrackGroup('Memory Usage')();

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -562,7 +562,6 @@ async function globalTrackProvider(engine: EngineProxy): Promise<TrackInfo[]> {
       trackKind: COUNTER_TRACK_KIND,
       name,
       description,
-      group: 'GPU Counters',
       config: {
         name,
         trackId,


### PR DESCRIPTION
Fixes https://github.com/android-graphics/sokatoa/issues/443
Move power tracks to Battery Group.
Make GPU Counters Group exclusively GPU Counters.