### PR TITLE
Match group chevrons to common app usage (e.g. Eclipse Theia)

### DIFF
--- a/ui/src/frontend/icons.ts
+++ b/ui/src/frontend/icons.ts
@@ -16,6 +16,7 @@ export const BLANK_CHECKBOX = 'check_box_outline_blank';
 export const CHECKBOX = 'check_box';
 export const INDETERMINATE_CHECKBOX = 'indeterminate_check_box';
 
+export const CHEVRON_RIGHT = 'chevron_right';
 export const EXPAND_DOWN = 'expand_more';
 export const EXPAND_UP = 'expand_less';
 

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -28,8 +28,8 @@ import {drawGridLines} from './gridline_helper';
 import {
   BLANK_CHECKBOX,
   CHECKBOX,
+  CHEVRON_RIGHT,
   EXPAND_DOWN,
-  EXPAND_UP,
   INDETERMINATE_CHECKBOX,
 } from './icons';
 import {Panel, PanelSize} from './panel';
@@ -159,7 +159,7 @@ export class TrackGroupPanel extends Panel<Attrs> {
           m('.fold-button',
             {...titleStyling},
             m('i.material-icons',
-              this.trackGroupState.collapsed ? EXPAND_DOWN : EXPAND_UP)),
+              this.trackGroupState.collapsed ? CHEVRON_RIGHT : EXPAND_DOWN)),
           m('.title-wrapper',
             {...titleStyling},
             m('h1.track-title',


### PR DESCRIPTION
- use rightward-pointing chevron (not accounting for RTL languages) for collapsed groups
- use downward-pointing chevron for expanded groups
