### PR TITLE
Add a LoadingManager reset for embedding applications

### DIFF
--- a/ui/src/controller/loading_manager.ts
+++ b/ui/src/controller/loading_manager.ts
@@ -25,6 +25,15 @@ export class LoadingManager implements LoadingTracker {
     return this._instance || (this._instance = new this());
   }
 
+  // Reset the loading manager to its initial state. This is useful
+  // in applications that embed the Perfetto UI and reuse it, to clear
+  // out lingering counts of queries that did not complete before the
+  // trace processor was stopped previously.
+  reset() {
+    this.numQueuedQueries = 0;
+    this.numLastUpdate = 0;
+  }
+
   beginLoading() {
     this.update(1);
   }


### PR DESCRIPTION
Provide an API for an embedding application to reset the LoadingManager on initialization of trace loading, when reusing the Perfetto UI after a previous trace was closed, which may leave a count of queued queries.
