### PR TITLE
Explicit location for type roots

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -18,5 +18,8 @@
     },
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
   }
 }


### PR DESCRIPTION
Explicitely define from which location typescript @types should be read from. Otherwise the tsc compiler possibly finds the types in a parent's folder node_modules/@types directory, which then causes build failures, as those files are not ignored as the local node_modules is.

In a sokatoa environment, this change allows to build perfetto without previously erasing the sokatoa node_modules folder, hence allowing a incremental build setup.

Please do not submit a Pull Request via GitHub.
Our project makes use of Gerrit for patch submission and review.

For more details please see
https://perfetto.dev/docs/contributing/getting-started

