### PR TITLE
Add/remove tracks and track groups in bulk

### DIFF
--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -2575,8 +2575,7 @@ class TrackDecider {
       }));
     }
 
-    actions.push(
-        ...this.trackGroupsToAdd.map(Actions.addTrackGroup));
+    actions.push(Actions.addTrackGroups({trackGroups: this.trackGroupsToAdd}));
     actions.push(Actions.addTracks({tracks: this.tracksToAdd}));
 
     const threadOrderingMetadata = await this.computeThreadOrderingMetadata();


### PR DESCRIPTION
Don't tie up the JS thread in immer.js productions by processing every track and track group deletion as a separate action. Bulk add track groups in the decider on initial load.
