### PR TITLE
Issue #623

### DIFF
--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -199,11 +199,13 @@ function removeTrackGroup(state: StateDraft, groupId: string) {
 // to represent the same track
 function isSameTrack(track: AddTrackArgs,
     other: Partial<AddTrackArgs>): boolean {
-  return track.kind === other.kind &&
-      track.trackGroup === other.trackGroup &&
-      // TODO: This may not be reliable. May need to deep-compare
-      // the config object
-      track.name === other.name;
+      // Compare based on Id
+      // If no id is present compare by other data
+  return track.id && track.id === other.id ||
+  (
+    track.kind === other.kind &&
+    track.trackGroup === other.trackGroup &&
+    track.name === other.name);
 }
 
 function unfilterTracklike(

--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -2868,7 +2868,7 @@ class TrackDecider {
     }
 
     this.trackGroupsToAdd.push(result);
-    this.tracksToAdd.push(this.blankSummaryTrack(id, name));
+    this.tracksToAdd.push(this.blankSummaryTrack(id, name + ' Summary Track'));
     return result;
   }
 

--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -482,7 +482,7 @@ class TrackDecider {
       where track.type = 'gpu_counter_track' and track.name is not null
     `);
     const trackNameToGroupName = new Map<string, string|null>();
-    const iter = groupingResult.iter({track_name: STR, group_name: STR_NULL})
+    const iter = groupingResult.iter({track_name: STR, group_name: STR_NULL});
     for (; iter.valid(); iter.next()) {
       trackNameToGroupName.set(iter.track_name, iter.group_name);
     }
@@ -2868,16 +2868,16 @@ class TrackDecider {
     }
 
     this.trackGroupsToAdd.push(result);
-    this.tracksToAdd.push(this.blankSummaryTrack(id));
+    this.tracksToAdd.push(this.blankSummaryTrack(id, name));
     return result;
   }
 
-  blankSummaryTrack(id: string): AddTrackArgs {
+  blankSummaryTrack(id: string, name: string): AddTrackArgs {
     return {
       engineId: this.engineId,
       id: id,
       kind: NULL_TRACK_KIND,
-      name: '',
+      name,
       trackSortKey: PrimaryTrackSortKey.NULL_TRACK,
       trackGroup: undefined,
       config: {},


### PR DESCRIPTION
https://github.com/android-graphics/sokatoa/issues/623
The reason this error was happening is because null summary tracks were being compared at a name level, but they all have empty string as a name.  Now their name will be the same as their track group's name.