### PR TITLE
Ensure consistent short sha in perfetto ui zip

### DIFF
--- a/.github/workflows/build-perfetto-ui.yml
+++ b/.github/workflows/build-perfetto-ui.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set Git Short SHA
         id: sha
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: echo "sha_short=$(git rev-parse --short=14 HEAD)" >> $GITHUB_OUTPUT
       - name: Install Dependencies
         run: tools/install-build-deps --ui
       - name: Run build


### PR DESCRIPTION
Specify value of 14 when getting the short commit sha to use
in the perfetto ui zip. This ensures we get the same length
for ay given commit, regardless of which version of git
is being used. In 2016, git was updated to use a default
short sha length based on the size of the repo. That means
that --short can return a different length depending on the
git version. 14 should be more than plenty to ensure
uniqueness