### PR TITLE
Issue 698 (An uncaught exception occurred: Uncaught Error: Topmost track group is unrendered when jumping to thread via link)

### DIFF
--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -964,7 +964,7 @@ export function getContainingTrackIds(state: State, trackId: string): null|
   }
 
   const result = [];
-  while (groupId) {
+  while (groupId && groupId !== SCROLLING_TRACK_GROUP) {
     result.unshift(groupId);
     const trackGroup: TrackGroupState = state.trackGroups[groupId];
     groupId = trackGroup?.parentGroup;


### PR DESCRIPTION
Issue: https://github.com/android-graphics/sokatoa/issues/698 (An uncaught exception occurred: Uncaught Error: Topmost track group is unrendered when jumping to thread via link)