### PR TITLE
Increase Track Height

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -48,7 +48,6 @@
 
 @mixin track_shell_title() {
   font-size: 14px;
-  max-height: 30px;
   overflow: hidden;
   text-align: left;
   overflow-wrap: break-word;

--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -667,7 +667,6 @@ button.query-ctrl {
   grid-template-columns: auto 1fr;
   grid-template-rows: 1fr;
   transition: background-color 0.4s, color 0.4s;
-  height: 40px;
 
   &::after {
     display: block;
@@ -745,7 +744,6 @@ button.query-ctrl {
     align-items: center;
     line-height: 1;
     width: var(--track-shell-width);
-    min-height: 40px;
     transition: background-color 0.4s;
 
     .track-title {

--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -375,6 +375,7 @@ export const StateActions = {
         `${track.name}\n\n${track.description}` :
         track.name;
       state.tracks[id] = track as TrackState;
+      state.tracks[id].scaleMultiplier=1;
       this.fillUiTrackIdByTraceTrackId(state, track as TrackState, id);
       if (track.trackGroup === SCROLLING_TRACK_GROUP) {
         state.scrollingTracks.push(id);
@@ -408,6 +409,7 @@ export const StateActions = {
       title: args.title,
       description,
       trackSortKey: args.trackSortKey,
+      scaleMultiplier: 1,
       trackGroup: args.trackGroup,
       config: args.config,
     };

--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -375,7 +375,7 @@ export const StateActions = {
         `${track.name}\n\n${track.description}` :
         track.name;
       state.tracks[id] = track as TrackState;
-      state.tracks[id].scaleMultiplier=1;
+      state.tracks[id].scaleFactor=1;
       this.fillUiTrackIdByTraceTrackId(state, track as TrackState, id);
       if (track.trackGroup === SCROLLING_TRACK_GROUP) {
         state.scrollingTracks.push(id);
@@ -409,7 +409,7 @@ export const StateActions = {
       title: args.title,
       description,
       trackSortKey: args.trackSortKey,
-      scaleMultiplier: 1,
+      scaleFactor: 1,
       trackGroup: args.trackGroup,
       config: args.config,
     };

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -245,7 +245,7 @@ export interface TrackState {
   labels?: string[];
   trackSortKey: TrackSortKey;
   trackGroup?: string;
-  scaleMultiplier: number;
+  scaleFactor: number;
   config: {
     trackId?: number;
     trackIds?: number[];

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -245,6 +245,7 @@ export interface TrackState {
   labels?: string[];
   trackSortKey: TrackSortKey;
   trackGroup?: string;
+  scaleMultiplier: number;
   config: {
     trackId?: number;
     trackIds?: number[];

--- a/ui/src/common/state_unittest.ts
+++ b/ui/src/common/state_unittest.ts
@@ -30,6 +30,7 @@ test('getContainingTrackId', () => {
     name: 'a track',
     description: 'this is a track',
     trackSortKey: PrimaryTrackSortKey.ORDINARY_TRACK,
+    scaleMultiplier: 1,
     config: {},
   };
 
@@ -40,6 +41,7 @@ test('getContainingTrackId', () => {
     name: 'b track',
     description: 'this is another track',
     trackSortKey: PrimaryTrackSortKey.ORDINARY_TRACK,
+    scaleMultiplier: 1,
     config: {},
     trackGroup: 'containsB',
   };

--- a/ui/src/common/state_unittest.ts
+++ b/ui/src/common/state_unittest.ts
@@ -30,7 +30,7 @@ test('getContainingTrackId', () => {
     name: 'a track',
     description: 'this is a track',
     trackSortKey: PrimaryTrackSortKey.ORDINARY_TRACK,
-    scaleMultiplier: 1,
+    scaleFactor: 1,
     config: {},
   };
 
@@ -41,7 +41,7 @@ test('getContainingTrackId', () => {
     name: 'b track',
     description: 'this is another track',
     trackSortKey: PrimaryTrackSortKey.ORDINARY_TRACK,
-    scaleMultiplier: 1,
+    scaleFactor: 1,
     config: {},
     trackGroup: 'containsB',
   };

--- a/ui/src/frontend/track.ts
+++ b/ui/src/frontend/track.ts
@@ -58,10 +58,10 @@ export abstract class Track<Config = {}, Data extends TrackData = TrackData> {
   protected readonly engine: Engine;
   private _supportsEnhancing: boolean = false;
 
-  get supportsEnhancing(): boolean {
+  get supportsResizing(): boolean {
     return this._supportsEnhancing;
   }
-  protected set supportsEnhancing(doesIt: boolean) {
+  protected set supportsResizing(doesIt: boolean) {
     this._supportsEnhancing = doesIt;
   }
   // When true this is a new controller-less track type.

--- a/ui/src/frontend/track.ts
+++ b/ui/src/frontend/track.ts
@@ -56,7 +56,14 @@ export abstract class Track<Config = {}, Data extends TrackData = TrackData> {
   // The UI-generated track ID (not to be confused with the SQL track.id).
   protected readonly trackId: string;
   protected readonly engine: Engine;
+  private _supportsEnhancing: boolean = false;
 
+  get supportsEnhancing(): boolean {
+    return this._supportsEnhancing;
+  }
+  protected set supportsEnhancing(doesIt: boolean) {
+    this._supportsEnhancing = doesIt;
+  }
   // When true this is a new controller-less track type.
   // TODO(hjd): eventually all tracks will be controller-less and this
   // should be removed then.

--- a/ui/src/frontend/track.ts
+++ b/ui/src/frontend/track.ts
@@ -56,13 +56,13 @@ export abstract class Track<Config = {}, Data extends TrackData = TrackData> {
   // The UI-generated track ID (not to be confused with the SQL track.id).
   protected readonly trackId: string;
   protected readonly engine: Engine;
-  private _supportsEnhancing: boolean = false;
+  private _supportsResizing: boolean = false;
 
   get supportsResizing(): boolean {
-    return this._supportsEnhancing;
+    return this._supportsResizing;
   }
   protected set supportsResizing(doesIt: boolean) {
-    this._supportsEnhancing = doesIt;
+    this._supportsResizing = doesIt;
   }
   // When true this is a new controller-less track type.
   // TODO(hjd): eventually all tracks will be controller-less and this

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -60,9 +60,11 @@ export class TrackGroupPanel extends Panel<Attrs> {
   // in trackGroupState() below.
   private lastTrackGroupState: TrackGroupState;
 
-  constructor({attrs}: m.CVnode<Attrs>) {
+  private initialHeight?: number;
+
+  constructor(protected attrs: m.CVnode<Attrs>) {
     super();
-    this.trackGroupId = attrs.trackGroupId;
+    this.trackGroupId = attrs.attrs.trackGroupId;
     const trackCreator = trackRegistry.get(this.summaryTrackState.kind);
     const engineId = this.summaryTrackState.engineId;
     const engine = globals.engines.get(engineId);
@@ -72,6 +74,9 @@ export class TrackGroupPanel extends Panel<Attrs> {
     }
     this.lastTrackGroupState = assertExists(
       globals.state.trackGroups[this.trackGroupId]);
+      if (this.summaryTrack) {
+        this.initialHeight = this.summaryTrack.getHeight();
+      }
   }
 
   get trackGroupState(): TrackGroupState {
@@ -92,6 +97,23 @@ export class TrackGroupPanel extends Panel<Attrs> {
 
   get summaryTrackState(): TrackState {
     return assertExists(globals.state.tracks[this.trackGroupState.tracks[0]]);
+  }
+
+  onmousemove(e: MouseEvent) {
+    if (this.summaryTrack && this.summaryTrack.supportsEnhancing) {
+      if (e.currentTarget instanceof HTMLElement &&
+        e.offsetY >= e.currentTarget.scrollHeight - 5) {
+          e.currentTarget.style.cursor = 'row-resize';
+      } else if (e.currentTarget instanceof HTMLElement) {
+        e.currentTarget.style.cursor = 'unset';
+      }
+    }
+  }
+  onmouseleave(e: MouseEvent) {
+    if (this.summaryTrack && this.summaryTrack.supportsEnhancing &&
+        e.currentTarget instanceof HTMLElement) {
+      e.currentTarget.style.cursor = 'unset';
+    }
   }
 
   view({attrs}: m.CVnode<Attrs>) {
@@ -149,7 +171,12 @@ export class TrackGroupPanel extends Panel<Attrs> {
     const dropClass = this.dropping ? `drop-${this.dropping}` : '';
     return m(
         `.track-group-panel[collapsed=${collapsed}]`,
-        {id: 'track_' + this.trackGroupId},
+        {
+          id: 'track_' + this.trackGroupId,
+          style: {
+            height: this.summaryTrack?`${Math.max(18, this.summaryTrack.getHeight())}px`:'unset',
+          },
+      },
         m(`.shell[draggable=true]`,
           {
             onclick: (e: MouseEvent) => {
@@ -168,6 +195,8 @@ export class TrackGroupPanel extends Panel<Attrs> {
             ondragover: this.ondragover.bind(this),
             ondragleave: this.ondragleave.bind(this),
             ondrop: this.ondrop.bind(this),
+            onmousemove: this.onmousemove.bind(this),
+            onmouseleave: this.onmouseleave.bind(this),
           },
 
           m('.fold-button',
@@ -200,21 +229,52 @@ export class TrackGroupPanel extends Panel<Attrs> {
 
         this.summaryTrack ?
             m(TrackContent,
-              {track: this.summaryTrack},
+              {
+                track: this.summaryTrack,
+              },
               (!this.trackGroupState.collapsed && child !== null) ?
                   m('span', child) :
                   null) :
             null);
   }
   ondragstart(e: DragEvent) {
-    const dataTransfer = e.dataTransfer;
-    if (dataTransfer === null) return;
-    this.dragging = true;
-    e.stopPropagation();
-    globals.rafScheduler.scheduleFullRedraw();
-    dataTransfer.effectAllowed = 'move';
-    dataTransfer.setData('perfetto/track/' + this.trackGroupId, `${this.trackGroupId}`);
-    dataTransfer.setDragImage(new Image(), 0, 0);
+    if (this.summaryTrack && this.summaryTrack.supportsEnhancing &&
+      e.target instanceof HTMLElement &&
+      e.offsetY >= e.target.scrollHeight - 5) {
+        e.stopPropagation();
+        e.preventDefault();
+        let y = e.offsetY;
+        let previousClientY =e.clientY;
+        const mouseMoveEvent = (evMove: MouseEvent): void => {
+            evMove.preventDefault();
+            y += (evMove.clientY -previousClientY);
+            previousClientY = evMove.clientY;
+            if (this.attrs && this.initialHeight) {
+              const newMultiplier = y / this.initialHeight;
+              if (newMultiplier<1) {
+                this.summaryTrackState.scaleMultiplier = 1;
+              } else {
+                this.summaryTrackState.scaleMultiplier = newMultiplier;
+              }
+              globals.rafScheduler.scheduleFullRedraw();
+            }
+        };
+        const mouseUpEvent = (): void => {
+            document.removeEventListener('mousemove', mouseMoveEvent);
+            document.removeEventListener('mouseup', mouseUpEvent);
+        };
+        document.addEventListener('mousemove', mouseMoveEvent);
+        document.addEventListener('mouseup', mouseUpEvent);
+    } else {
+      const dataTransfer = e.dataTransfer;
+      if (dataTransfer === null) return;
+      this.dragging = true;
+      e.stopPropagation();
+      globals.rafScheduler.scheduleFullRedraw();
+      dataTransfer.effectAllowed = 'move';
+      dataTransfer.setData('perfetto/track/' + this.trackGroupId, `${this.trackGroupId}`);
+      dataTransfer.setDragImage(new Image(), 0, 0);
+    }
   }
 
   ondragend() {

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -47,6 +47,7 @@ interface Attrs {
   selectable: boolean;
 }
 
+const MOUSE_TARGETING_THRESHOLD_PX = 5;
 export class TrackGroupPanel extends Panel<Attrs> {
   private readonly trackGroupId: string;
   private shellWidth = 0;
@@ -100,9 +101,11 @@ export class TrackGroupPanel extends Panel<Attrs> {
   }
 
   onmousemove(e: MouseEvent) {
-    if (this.summaryTrack && this.summaryTrack.supportsEnhancing) {
+    if (this.summaryTrack && this.summaryTrack.supportsResizing) {
       if (e.currentTarget instanceof HTMLElement &&
-        e.offsetY >= e.currentTarget.scrollHeight - 5) {
+          e.offsetY >=
+          e.currentTarget.scrollHeight - MOUSE_TARGETING_THRESHOLD_PX
+          ) {
           e.currentTarget.style.cursor = 'row-resize';
       } else if (e.currentTarget instanceof HTMLElement) {
         e.currentTarget.style.cursor = 'unset';
@@ -110,7 +113,7 @@ export class TrackGroupPanel extends Panel<Attrs> {
     }
   }
   onmouseleave(e: MouseEvent) {
-    if (this.summaryTrack && this.summaryTrack.supportsEnhancing &&
+    if (this.summaryTrack && this.summaryTrack.supportsResizing &&
         e.currentTarget instanceof HTMLElement) {
       e.currentTarget.style.cursor = 'unset';
     }
@@ -238,23 +241,23 @@ export class TrackGroupPanel extends Panel<Attrs> {
             null);
   }
   ondragstart(e: DragEvent) {
-    if (this.summaryTrack && this.summaryTrack.supportsEnhancing &&
+    if (this.summaryTrack && this.summaryTrack.supportsResizing &&
       e.target instanceof HTMLElement &&
-      e.offsetY >= e.target.scrollHeight - 5) {
+      e.offsetY >= e.target.scrollHeight - MOUSE_TARGETING_THRESHOLD_PX) {
         e.stopPropagation();
         e.preventDefault();
         let y = e.offsetY;
-        let previousClientY =e.clientY;
+        let previousClientY = e.clientY;
         const mouseMoveEvent = (evMove: MouseEvent): void => {
             evMove.preventDefault();
             y += (evMove.clientY -previousClientY);
             previousClientY = evMove.clientY;
             if (this.attrs && this.initialHeight) {
               const newMultiplier = y / this.initialHeight;
-              if (newMultiplier<1) {
-                this.summaryTrackState.scaleMultiplier = 1;
+              if (newMultiplier < 1) {
+                this.summaryTrackState.scaleFactor = 1;
               } else {
-                this.summaryTrackState.scaleMultiplier = newMultiplier;
+                this.summaryTrackState.scaleFactor = newMultiplier;
               }
               globals.rafScheduler.scheduleFullRedraw();
             }

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -76,8 +76,13 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
   private dropping: 'before'|'after'|undefined = undefined;
   private attrs?: TrackShellAttrs;
 
+  private initialHeight?: number;
+
   oninit(vnode: m.Vnode<TrackShellAttrs>) {
     this.attrs = vnode.attrs;
+    if (this.attrs) {
+      this.initialHeight = this.attrs.track.getHeight();
+    }
   }
 
   view({attrs}: m.CVnode<TrackShellAttrs>) {
@@ -105,6 +110,8 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
 
     const dragClass = this.dragging ? `drag` : '';
     const dropClass = this.dropping ? `drop-${this.dropping}` : '';
+
+
     return m(
         `.track-shell[draggable=true]`,
         {
@@ -118,6 +125,8 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
           ondragover: this.ondragover.bind(this),
           ondragleave: this.ondragleave.bind(this),
           ondrop: this.ondrop.bind(this),
+          onmousemove: this.onmousemove.bind(this),
+          onmouseleave: this.onmouseleave.bind(this),
         },
         m(
             'h1',
@@ -160,15 +169,57 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
               ''));
   }
 
+  onmousemove(e: MouseEvent) {
+    if (this.attrs?.track.supportsEnhancing) {
+      if (e.currentTarget instanceof HTMLElement &&
+        e.offsetY >= e.currentTarget.scrollHeight - 5) {
+          e.currentTarget.style.cursor = 'row-resize';
+      } else if (e.currentTarget instanceof HTMLElement) {
+        e.currentTarget.style.cursor = 'unset';
+      }
+    }
+  }
+  onmouseleave(e: MouseEvent) {
+    if (this.attrs?.track.supportsEnhancing &&
+        e.currentTarget instanceof HTMLElement) {
+      e.currentTarget.style.cursor = 'unset';
+    }
+  }
+
   ondragstart(e: DragEvent) {
-    const dataTransfer = e.dataTransfer;
-    if (dataTransfer === null) return;
-    this.dragging = true;
-    e.stopPropagation();
-    globals.rafScheduler.scheduleFullRedraw();
-    dataTransfer.effectAllowed = 'move';
-    dataTransfer.setData('perfetto/track/' + this.attrs!.trackState.id, `${this.attrs!.trackState.id}`);
-    dataTransfer.setDragImage(new Image(), 0, 0);
+    if (this.attrs?.track.supportsEnhancing &&
+      e.target instanceof HTMLElement &&
+      e.offsetY >= e.target.scrollHeight - 5) {
+        e.stopPropagation();
+        e.preventDefault();
+        let y = e.offsetY;
+        let previousClientY =e.clientY;
+        const mouseMoveEvent = (evMove: MouseEvent): void => {
+            evMove.preventDefault();
+            y += (evMove.clientY -previousClientY);
+            previousClientY = evMove.clientY;
+            if (this.attrs && this.initialHeight) {
+                this.attrs.trackState.scaleMultiplier =
+                y / this.initialHeight;
+                globals.rafScheduler.scheduleFullRedraw();
+            }
+        };
+        const mouseUpEvent = (): void => {
+            document.removeEventListener('mousemove', mouseMoveEvent);
+            document.removeEventListener('mouseup', mouseUpEvent);
+        };
+        document.addEventListener('mousemove', mouseMoveEvent);
+        document.addEventListener('mouseup', mouseUpEvent);
+    } else {
+      const dataTransfer = e.dataTransfer;
+      if (dataTransfer === null) return;
+      this.dragging = true;
+      e.stopPropagation();
+      globals.rafScheduler.scheduleFullRedraw();
+        dataTransfer.effectAllowed = 'move';
+        dataTransfer.setData('perfetto/track/' + this.attrs!.trackState.id, `${this.attrs!.trackState.id}`);
+        dataTransfer.setDragImage(new Image(), 0, 0);
+    }
   }
 
   ondragend() {

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -292,18 +292,6 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       fullHeight: true,
       disabled: !this.canDeleteTrack(attrs.trackState),
     }));
-    if (attrs.track.supportsEnhancing) {
-      result.push(m(TrackButton, {
-        action: () => {
-          globals.state.tracks[attrs.trackState.id].scaleMultiplier++;
-          globals.rafScheduler.scheduleFullRedraw();
-        },
-        i: 'height',
-        tooltip: 'Enhance',
-        showButton: false, // Only show on roll-over
-        fullHeight: true,
-      }));
-    }
     return result;
   }
 

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -241,16 +241,18 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       fullHeight: true,
       disabled: !this.canDeleteTrack(attrs.trackState),
     }));
-    result.push(m(TrackButton, {
-      action: () => {
-        globals.state.tracks[attrs.trackState.id].scaleMultiplier++;
-        globals.rafScheduler.scheduleFullRedraw();
-      },
-      i: 'height',
-      tooltip: 'Enhance',
-      showButton: false, // Only show on roll-over
-      fullHeight: true,
-    }));
+    if (attrs.track.supportsEnhancing) {
+      result.push(m(TrackButton, {
+        action: () => {
+          globals.state.tracks[attrs.trackState.id].scaleMultiplier++;
+          globals.rafScheduler.scheduleFullRedraw();
+        },
+        i: 'height',
+        tooltip: 'Enhance',
+        showButton: false, // Only show on roll-over
+        fullHeight: true,
+      }));
+    }
     return result;
   }
 

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -199,9 +199,13 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
             y += (evMove.clientY -previousClientY);
             previousClientY = evMove.clientY;
             if (this.attrs && this.initialHeight) {
-                this.attrs.trackState.scaleMultiplier =
-                y / this.initialHeight;
-                globals.rafScheduler.scheduleFullRedraw();
+              const newMultiplier = y / this.initialHeight;
+              if (newMultiplier<1) {
+                this.attrs.trackState.scaleMultiplier = 1;
+              } else {
+                this.attrs.trackState.scaleMultiplier = newMultiplier;
+              }
+              globals.rafScheduler.scheduleFullRedraw();
             }
         };
         const mouseUpEvent = (): void => {

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -170,7 +170,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
   }
 
   onmousemove(e: MouseEvent) {
-    if (this.attrs?.track.supportsEnhancing) {
+    if (this.attrs?.track.supportsResizing) {
       if (e.currentTarget instanceof HTMLElement &&
         e.offsetY >= e.currentTarget.scrollHeight - 5) {
           e.currentTarget.style.cursor = 'row-resize';
@@ -180,30 +180,30 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
     }
   }
   onmouseleave(e: MouseEvent) {
-    if (this.attrs?.track.supportsEnhancing &&
+    if (this.attrs?.track.supportsResizing &&
         e.currentTarget instanceof HTMLElement) {
       e.currentTarget.style.cursor = 'unset';
     }
   }
 
   ondragstart(e: DragEvent) {
-    if (this.attrs?.track.supportsEnhancing &&
+    if (this.attrs?.track.supportsResizing &&
       e.target instanceof HTMLElement &&
       e.offsetY >= e.target.scrollHeight - 5) {
         e.stopPropagation();
         e.preventDefault();
         let y = e.offsetY;
-        let previousClientY =e.clientY;
+        let previousClientY = e.clientY;
         const mouseMoveEvent = (evMove: MouseEvent): void => {
             evMove.preventDefault();
             y += (evMove.clientY -previousClientY);
             previousClientY = evMove.clientY;
             if (this.attrs && this.initialHeight) {
               const newMultiplier = y / this.initialHeight;
-              if (newMultiplier<1) {
-                this.attrs.trackState.scaleMultiplier = 1;
+              if (newMultiplier < 1) {
+                this.attrs.trackState.scaleFactor = 1;
               } else {
-                this.attrs.trackState.scaleMultiplier = newMultiplier;
+                this.attrs.trackState.scaleFactor = newMultiplier;
               }
               globals.rafScheduler.scheduleFullRedraw();
             }

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -241,6 +241,16 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       fullHeight: true,
       disabled: !this.canDeleteTrack(attrs.trackState),
     }));
+    result.push(m(TrackButton, {
+      action: () => {
+        globals.state.tracks[attrs.trackState.id].scaleMultiplier++;
+        globals.rafScheduler.scheduleFullRedraw();
+      },
+      i: 'height',
+      tooltip: 'Enhance',
+      showButton: false, // Only show on roll-over
+      fullHeight: true,
+    }));
     return result;
   }
 

--- a/ui/src/tracks/chrome_slices/index.ts
+++ b/ui/src/tracks/chrome_slices/index.ts
@@ -175,6 +175,7 @@ export class ChromeSliceTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
+    this.supportsEnhancing = true;
   }
 
   // Font used to render the slice name on the current track.

--- a/ui/src/tracks/chrome_slices/index.ts
+++ b/ui/src/tracks/chrome_slices/index.ts
@@ -175,20 +175,20 @@ export class ChromeSliceTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
-    this.supportsEnhancing = true;
+    this.supportsResizing = true;
   }
 
   // Font used to render the slice name on the current track.
   protected getFont() {
-    sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleMultiplier;
+    sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleFactor;
 
-    return Math.floor(sliceHeight * (2/3)) + 'px Roboto Condensed';
+    return Math.floor(sliceHeight * 2 / 3) + 'px Roboto Condensed';
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D): void {
     // TODO: fonts and colors should come from the CSS and not hardcoded here.
 
-    sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleMultiplier;
+    sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleFactor;
     const {visibleTimeScale, visibleWindowTime} = globals.frontendLocalState;
     const data = this.data();
 
@@ -381,7 +381,7 @@ export class ChromeSliceTrack extends Track<Config, Data> {
     if (y < TRACK_PADDING) return;
     const instantWidthTime = timeScale.pxDeltaToDuration(HALF_CHEVRON_WIDTH_PX);
     const t = timeScale.pxToHpTime(x);
-    sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleMultiplier;
+    sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleFactor;
     const depth = Math.floor((y - TRACK_PADDING) / sliceHeight);
 
     for (let i = 0; i < data.starts.length; i++) {
@@ -440,7 +440,7 @@ export class ChromeSliceTrack extends Track<Config, Data> {
   }
 
   getHeight() {
-    sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleMultiplier;
+    sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleFactor;
     return sliceHeight * (this.config.maxDepth + 1) + 2 * TRACK_PADDING;
   }
 
@@ -458,7 +458,7 @@ export class ChromeSliceTrack extends Track<Config, Data> {
 
     const visible =
         !(visibleWindowTime.start.gt(tEnd) || visibleWindowTime.end.lt(tStart));
-        sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleMultiplier;
+        sliceHeight = DEFAULT_SLICE_HEIGHT * this.trackState.scaleFactor;
     return {
       left,
       width: Math.max(right - left, 1),

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -222,7 +222,7 @@ class CounterTrackController extends TrackController<Config, Data> {
 
 // 0.5 Makes the horizontal lines sharp.
 const MARGIN_TOP = 3.5;
-const RECT_HEIGHT = 24.5;
+const RECT_HEIGHT = 25.5;
 
 class CounterTrack extends Track<Config, Data> {
   static readonly kind = COUNTER_TRACK_KIND;
@@ -234,13 +234,14 @@ class CounterTrack extends Track<Config, Data> {
   private hoveredValue: number|undefined = undefined;
   private hoveredTs: bigint|undefined = undefined;
   private hoveredTsEnd: bigint|undefined = undefined;
+  multiplier = 1;
 
   constructor(args: NewTrackArgs) {
     super(args);
   }
 
   getHeight() {
-    return MARGIN_TOP + RECT_HEIGHT;
+    return MARGIN_TOP + (RECT_HEIGHT * this.multiplier);
   }
 
   getContextMenu(): m.Vnode<any> {
@@ -271,7 +272,9 @@ class CounterTrack extends Track<Config, Data> {
           trigger: m('button',
           m(TrackButton,
             {
-              action: ()=>{},
+              action: ()=>{
+                this.multiplier++;
+              },
               i: 'show_chart',
               tooltip: 'Change scale',
               showButton: false,
@@ -324,7 +327,8 @@ class CounterTrack extends Track<Config, Data> {
     }
 
     const endPx = windowSpan.end;
-    const zeroY = MARGIN_TOP + RECT_HEIGHT / (minimumValue < 0 ? 2 : 1);
+    const zeroY = MARGIN_TOP + (RECT_HEIGHT * this.multiplier) /
+     (minimumValue < 0 ? 2 : 1);
 
     // Quantize the Y axis to quarters of powers of tens (7.5K, 10K, 12.5K).
     const maxValue = Math.max(maximumValue, 0);
@@ -371,8 +375,8 @@ class CounterTrack extends Track<Config, Data> {
       return Math.floor(timeScale.tpTimeToPx(ts));
     };
     const calculateY = (value: number) => {
-      return MARGIN_TOP + RECT_HEIGHT -
-          Math.round(((value - yMin) / yRange) * RECT_HEIGHT);
+      return MARGIN_TOP + (RECT_HEIGHT*this.multiplier) -
+          Math.round(((value - yMin) / yRange) * RECT_HEIGHT * this.multiplier);
     };
 
     ctx.beginPath();
@@ -433,8 +437,9 @@ class CounterTrack extends Track<Config, Data> {
       const xEnd = this.hoveredTsEnd === undefined ?
           endPx :
           Math.floor(timeScale.tpTimeToPx(this.hoveredTsEnd));
-      const y = MARGIN_TOP + RECT_HEIGHT -
-          Math.round(((this.hoveredValue - yMin) / yRange) * RECT_HEIGHT);
+      const y = MARGIN_TOP + (RECT_HEIGHT * this.multiplier) -
+          Math.round(((this.hoveredValue - yMin) / yRange) * RECT_HEIGHT *
+          this.multiplier);
 
       // Highlight line.
       ctx.beginPath();

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -237,6 +237,7 @@ class CounterTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
+    this.supportsEnhancing = true;
   }
 
   getHeight() {

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -237,11 +237,11 @@ class CounterTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
-    this.supportsEnhancing = true;
+    this.supportsResizing = true;
   }
 
   getHeight() {
-    return MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier);
+    return MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleFactor);
   }
 
   getContextMenu(): m.Vnode<any> {
@@ -325,7 +325,7 @@ class CounterTrack extends Track<Config, Data> {
     }
 
     const endPx = windowSpan.end;
-    const zeroY = MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier) /
+    const zeroY = MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleFactor) /
      (minimumValue < 0 ? 2 : 1);
 
     // Quantize the Y axis to quarters of powers of tens (7.5K, 10K, 12.5K).
@@ -373,9 +373,9 @@ class CounterTrack extends Track<Config, Data> {
       return Math.floor(timeScale.tpTimeToPx(ts));
     };
     const calculateY = (value: number) => {
-      return MARGIN_TOP + (RECT_HEIGHT*this.trackState.scaleMultiplier) -
+      return MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleFactor) -
           Math.round(((value - yMin) / yRange) *
-            RECT_HEIGHT * this.trackState.scaleMultiplier);
+            RECT_HEIGHT * this.trackState.scaleFactor);
     };
 
     ctx.beginPath();
@@ -436,9 +436,9 @@ class CounterTrack extends Track<Config, Data> {
       const xEnd = this.hoveredTsEnd === undefined ?
           endPx :
           Math.floor(timeScale.tpTimeToPx(this.hoveredTsEnd));
-      const y = MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier) -
+      const y = MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleFactor) -
           Math.round(((this.hoveredValue - yMin) / yRange) * RECT_HEIGHT *
-          this.trackState.scaleMultiplier);
+          this.trackState.scaleFactor);
 
       // Highlight line.
       ctx.beginPath();

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -234,14 +234,13 @@ class CounterTrack extends Track<Config, Data> {
   private hoveredValue: number|undefined = undefined;
   private hoveredTs: bigint|undefined = undefined;
   private hoveredTsEnd: bigint|undefined = undefined;
-  multiplier = 1;
 
   constructor(args: NewTrackArgs) {
     super(args);
   }
 
   getHeight() {
-    return MARGIN_TOP + (RECT_HEIGHT * this.multiplier);
+    return MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier);
   }
 
   getContextMenu(): m.Vnode<any> {
@@ -272,9 +271,7 @@ class CounterTrack extends Track<Config, Data> {
           trigger: m('button',
           m(TrackButton,
             {
-              action: ()=>{
-                this.multiplier++;
-              },
+              action: ()=>{},
               i: 'show_chart',
               tooltip: 'Change scale',
               showButton: false,
@@ -327,7 +324,7 @@ class CounterTrack extends Track<Config, Data> {
     }
 
     const endPx = windowSpan.end;
-    const zeroY = MARGIN_TOP + (RECT_HEIGHT * this.multiplier) /
+    const zeroY = MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier) /
      (minimumValue < 0 ? 2 : 1);
 
     // Quantize the Y axis to quarters of powers of tens (7.5K, 10K, 12.5K).
@@ -375,8 +372,9 @@ class CounterTrack extends Track<Config, Data> {
       return Math.floor(timeScale.tpTimeToPx(ts));
     };
     const calculateY = (value: number) => {
-      return MARGIN_TOP + (RECT_HEIGHT*this.multiplier) -
-          Math.round(((value - yMin) / yRange) * RECT_HEIGHT * this.multiplier);
+      return MARGIN_TOP + (RECT_HEIGHT*this.trackState.scaleMultiplier) -
+          Math.round(((value - yMin) / yRange) *
+            RECT_HEIGHT * this.trackState.scaleMultiplier);
     };
 
     ctx.beginPath();
@@ -437,9 +435,9 @@ class CounterTrack extends Track<Config, Data> {
       const xEnd = this.hoveredTsEnd === undefined ?
           endPx :
           Math.floor(timeScale.tpTimeToPx(this.hoveredTsEnd));
-      const y = MARGIN_TOP + (RECT_HEIGHT * this.multiplier) -
+      const y = MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier) -
           Math.round(((this.hoveredValue - yMin) / yRange) * RECT_HEIGHT *
-          this.multiplier);
+          this.trackState.scaleMultiplier);
 
       // Highlight line.
       ctx.beginPath();

--- a/ui/src/tracks/cpu_freq/index.ts
+++ b/ui/src/tracks/cpu_freq/index.ts
@@ -279,6 +279,7 @@ class CpuFreqTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
+    this.supportsEnhancing = true;
   }
 
   getHeight() {

--- a/ui/src/tracks/cpu_freq/index.ts
+++ b/ui/src/tracks/cpu_freq/index.ts
@@ -279,11 +279,11 @@ class CpuFreqTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
-    this.supportsEnhancing = true;
+    this.supportsResizing = true;
   }
 
   getHeight() {
-    return MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier);
+    return MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleFactor);
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D): void {
@@ -306,7 +306,7 @@ class CpuFreqTrack extends Track<Config, Data> {
     assertTrue(data.timestamps.length === data.lastIdleValues.length);
 
     const endPx = windowSpan.end;
-    const zeroY = MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier);
+    const zeroY = MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleFactor);
 
     // Quantize the Y axis to quarters of powers of tens (7.5K, 10K, 12.5K).
     let yMax = data.maximumValue;
@@ -333,7 +333,7 @@ class CpuFreqTrack extends Track<Config, Data> {
     };
     const calculateY = (value: number) => {
       return zeroY - Math.round((value / yMax) *
-        (RECT_HEIGHT * this.trackState.scaleMultiplier));
+        (RECT_HEIGHT * this.trackState.scaleFactor));
     };
 
     const start = visibleWindowTime.start;
@@ -412,7 +412,7 @@ class CpuFreqTrack extends Track<Config, Data> {
           endPx :
           Math.floor(visibleTimeScale.tpTimeToPx(this.hoveredTsEnd));
       const y = zeroY - Math.round((this.hoveredValue / yMax) *
-        (RECT_HEIGHT * this.trackState.scaleMultiplier));
+        (RECT_HEIGHT * this.trackState.scaleFactor));
 
       // Highlight line.
       ctx.beginPath();

--- a/ui/src/tracks/cpu_freq/index.ts
+++ b/ui/src/tracks/cpu_freq/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { getCssStr } from '../../frontend/css_constants';
+import {getCssStr} from '../../frontend/css_constants';
 import {BigintMath as BIMath} from '../../base/bigint_math';
 import {searchSegment} from '../../base/binary_search';
 import {assertTrue} from '../../base/logging';
@@ -282,7 +282,7 @@ class CpuFreqTrack extends Track<Config, Data> {
   }
 
   getHeight() {
-    return MARGIN_TOP + RECT_HEIGHT;
+    return MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier);
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D): void {
@@ -305,7 +305,7 @@ class CpuFreqTrack extends Track<Config, Data> {
     assertTrue(data.timestamps.length === data.lastIdleValues.length);
 
     const endPx = windowSpan.end;
-    const zeroY = MARGIN_TOP + RECT_HEIGHT;
+    const zeroY = MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier);
 
     // Quantize the Y axis to quarters of powers of tens (7.5K, 10K, 12.5K).
     let yMax = data.maximumValue;
@@ -331,7 +331,8 @@ class CpuFreqTrack extends Track<Config, Data> {
       return Math.floor(visibleTimeScale.tpTimeToPx(timestamp));
     };
     const calculateY = (value: number) => {
-      return zeroY - Math.round((value / yMax) * RECT_HEIGHT);
+      return zeroY - Math.round((value / yMax) *
+        (RECT_HEIGHT * this.trackState.scaleMultiplier));
     };
 
     const start = visibleWindowTime.start;
@@ -409,7 +410,8 @@ class CpuFreqTrack extends Track<Config, Data> {
       const xEnd = this.hoveredTsEnd === undefined ?
           endPx :
           Math.floor(visibleTimeScale.tpTimeToPx(this.hoveredTsEnd));
-      const y = zeroY - Math.round((this.hoveredValue / yMax) * RECT_HEIGHT);
+      const y = zeroY - Math.round((this.hoveredValue / yMax) *
+        (RECT_HEIGHT * this.trackState.scaleMultiplier));
 
       // Highlight line.
       ctx.beginPath();

--- a/ui/src/tracks/cpu_slices/index.ts
+++ b/ui/src/tracks/cpu_slices/index.ts
@@ -395,15 +395,16 @@ class CpuSliceTrack extends Track<Config, Data> {
           // Latency time background.
           const latency = tStart - details.wakeupTs;
           const displayText = tpTimeToString(latency);
+          ctx.font = subTextSize + 'px Roboto Condensed';
           const measured = ctx.measureText(displayText);
           if (latencyWidth >= measured.width + 2) {
             ctx.fillStyle = getCssStr('--main-background-color');
             ctx.fillRect(
                 wakeupPos + latencyWidth / 2 - measured.width / 2 - 1,
                 MARGIN_TOP +
-                  (RECT_HEIGHT * this.trackState.scaleMultiplier) - 12,
+                  (RECT_HEIGHT * this.trackState.scaleMultiplier / 2),
                 measured.width + 2,
-                11);
+                (RECT_HEIGHT * this.trackState.scaleMultiplier /2)- MARGIN_TOP);
             ctx.textBaseline = 'bottom';
             ctx.fillStyle = getCssStr('--main-foreground-color');
             ctx.fillText(

--- a/ui/src/tracks/cpu_slices/index.ts
+++ b/ui/src/tracks/cpu_slices/index.ts
@@ -219,11 +219,11 @@ class CpuSliceTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
-    this.supportsEnhancing = true;
+    this.supportsResizing = true;
   }
 
   getHeight(): number {
-    return (MARGIN_TOP * 2) + (RECT_HEIGHT * this.trackState.scaleMultiplier);
+    return (MARGIN_TOP * 2) + (RECT_HEIGHT * this.trackState.scaleFactor);
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D): void {
@@ -259,9 +259,9 @@ class CpuSliceTrack extends Track<Config, Data> {
 
     ctx.textAlign = 'center';
     const mainTextSize =
-      Math.floor((RECT_HEIGHT * this.trackState.scaleMultiplier)*0.50);
+       Math.floor((RECT_HEIGHT * this.trackState.scaleFactor) * 0.50);
     const subTextSize =
-      Math.floor((RECT_HEIGHT * this.trackState.scaleMultiplier)*0.40);
+      Math.floor((RECT_HEIGHT * this.trackState.scaleFactor) * 0.40);
 
     ctx.font = mainTextSize + 'px Roboto Condensed';
     const charWidth = ctx.measureText('dbpqaouk').width / 8;
@@ -312,10 +312,10 @@ class CpuSliceTrack extends Track<Config, Data> {
       ctx.fillStyle = `hsl(${color.h}, ${color.s}%, ${color.l}%)`;
       if (data.isIncomplete[i]) {
         drawIncompleteSlice(ctx, rectStart, MARGIN_TOP, rectWidth,
-          (RECT_HEIGHT * this.trackState.scaleMultiplier));
+          (RECT_HEIGHT * this.trackState.scaleFactor));
       } else {
         ctx.fillRect(rectStart, MARGIN_TOP, rectWidth,
-          (RECT_HEIGHT * this.trackState.scaleMultiplier));
+          (RECT_HEIGHT * this.trackState.scaleFactor));
       }
 
       // Don't render text when we have less than 5px to play with.
@@ -348,7 +348,7 @@ class CpuSliceTrack extends Track<Config, Data> {
         charWidth,
         visibleWidth);
       ctx.fillText(title, rectXCenter,
-        MARGIN_TOP + (RECT_HEIGHT*this.trackState.scaleMultiplier/2));
+        MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleFactor/2));
       ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
       ctx.font = subTextSize + 'px Roboto Condensed';
       subTitle = cropText(subTitle,
@@ -356,7 +356,7 @@ class CpuSliceTrack extends Track<Config, Data> {
         visibleWidth);
       ctx.fillText(subTitle, rectXCenter,
         MARGIN_TOP +
-        (RECT_HEIGHT*this.trackState.scaleMultiplier/2) +
+        (RECT_HEIGHT * this.trackState.scaleFactor/2) +
         subTextSize);
     }
 
@@ -378,7 +378,7 @@ class CpuSliceTrack extends Track<Config, Data> {
         ctx.beginPath();
         ctx.lineWidth = 3;
         ctx.strokeRect(rectStart, MARGIN_TOP - 1.5, rectWidth,
-          (RECT_HEIGHT * this.trackState.scaleMultiplier) + 3);
+          (RECT_HEIGHT * this.trackState.scaleFactor) + 3);
         ctx.closePath();
         // Draw arrow from wakeup time of current slice.
         if (details.wakeupTs) {
@@ -387,7 +387,7 @@ class CpuSliceTrack extends Track<Config, Data> {
           drawDoubleHeadedArrow(
               ctx,
               wakeupPos,
-              MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier),
+              MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleFactor),
               latencyWidth,
               latencyWidth >= 20,
               2,
@@ -402,16 +402,16 @@ class CpuSliceTrack extends Track<Config, Data> {
             ctx.fillRect(
                 wakeupPos + latencyWidth / 2 - measured.width / 2 - 1,
                 MARGIN_TOP +
-                  (RECT_HEIGHT * this.trackState.scaleMultiplier / 2),
+                  (RECT_HEIGHT * this.trackState.scaleFactor / 2),
                 measured.width + 2,
-                (RECT_HEIGHT * this.trackState.scaleMultiplier /2)- MARGIN_TOP);
+                (RECT_HEIGHT * this.trackState.scaleFactor / 2)- MARGIN_TOP);
             ctx.textBaseline = 'bottom';
             ctx.fillStyle = getCssStr('--main-foreground-color');
             ctx.fillText(
                 displayText,
                 wakeupPos + (latencyWidth) / 2,
                 MARGIN_TOP +
-                  (RECT_HEIGHT * this.trackState.scaleMultiplier) - 1);
+                  (RECT_HEIGHT * this.trackState.scaleFactor) - 1);
           }
         }
       }
@@ -422,14 +422,14 @@ class CpuSliceTrack extends Track<Config, Data> {
             Math.floor(visibleTimeScale.tpTimeToPx(details.wakeupTs));
         ctx.beginPath();
         ctx.moveTo(wakeupPos, MARGIN_TOP +
-          (RECT_HEIGHT * this.trackState.scaleMultiplier) / 2 + 8);
+          (RECT_HEIGHT * this.trackState.scaleFactor) / 2 + 8);
         ctx.fillStyle = getCssStr('--main-foreground-color');
         ctx.lineTo(wakeupPos + 6, MARGIN_TOP +
-          (RECT_HEIGHT * this.trackState.scaleMultiplier) / 2);
+          (RECT_HEIGHT * this.trackState.scaleFactor) / 2);
         ctx.lineTo(wakeupPos, MARGIN_TOP +
-          (RECT_HEIGHT * this.trackState.scaleMultiplier) / 2 - 8);
+          (RECT_HEIGHT * this.trackState.scaleFactor) / 2 - 8);
         ctx.lineTo(wakeupPos - 6, MARGIN_TOP +
-          (RECT_HEIGHT * this.trackState.scaleMultiplier) / 2);
+          (RECT_HEIGHT * this.trackState.scaleFactor) / 2);
         ctx.fill();
         ctx.closePath();
       }
@@ -453,7 +453,7 @@ class CpuSliceTrack extends Track<Config, Data> {
     if (data === undefined) return;
     const {visibleTimeScale} = globals.frontendLocalState;
     if (pos.y < MARGIN_TOP ||
-        pos.y > MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier)) {
+        pos.y > MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleFactor)) {
       this.utidHoveredInThisTrack = -1;
       globals.dispatch(Actions.setHoveredUtidAndPid({utid: -1, pid: -1}));
       return;

--- a/ui/src/tracks/cpu_slices/index.ts
+++ b/ui/src/tracks/cpu_slices/index.ts
@@ -219,6 +219,7 @@ class CpuSliceTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
+    this.supportsEnhancing = true;
   }
 
   getHeight(): number {

--- a/ui/src/tracks/cpu_slices/index.ts
+++ b/ui/src/tracks/cpu_slices/index.ts
@@ -207,7 +207,6 @@ class CpuSliceTrackController extends TrackController<Config, Data> {
 
 const MARGIN_TOP = 3;
 const RECT_HEIGHT = 24;
-const TRACK_HEIGHT = MARGIN_TOP * 2 + RECT_HEIGHT;
 
 class CpuSliceTrack extends Track<Config, Data> {
   static readonly kind = CPU_SLICE_TRACK_KIND;
@@ -223,7 +222,7 @@ class CpuSliceTrack extends Track<Config, Data> {
   }
 
   getHeight(): number {
-    return TRACK_HEIGHT;
+    return (MARGIN_TOP * 2) + (RECT_HEIGHT * this.trackState.scaleMultiplier);
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D): void {
@@ -258,7 +257,12 @@ class CpuSliceTrack extends Track<Config, Data> {
     const visWindowEndPx = visibleTimeScale.hpTimeToPx(visibleWindowTime.end);
 
     ctx.textAlign = 'center';
-    ctx.font = '12px Roboto Condensed';
+    const mainTextSize =
+      Math.floor((RECT_HEIGHT * this.trackState.scaleMultiplier)*0.50);
+    const subTextSize =
+      Math.floor((RECT_HEIGHT * this.trackState.scaleMultiplier)*0.40);
+
+    ctx.font = mainTextSize + 'px Roboto Condensed';
     const charWidth = ctx.measureText('dbpqaouk').width / 8;
 
     const startTime = visibleTimeSpan.start;
@@ -306,9 +310,11 @@ class CpuSliceTrack extends Track<Config, Data> {
       }
       ctx.fillStyle = `hsl(${color.h}, ${color.s}%, ${color.l}%)`;
       if (data.isIncomplete[i]) {
-        drawIncompleteSlice(ctx, rectStart, MARGIN_TOP, rectWidth, RECT_HEIGHT);
+        drawIncompleteSlice(ctx, rectStart, MARGIN_TOP, rectWidth,
+          (RECT_HEIGHT * this.trackState.scaleMultiplier));
       } else {
-        ctx.fillRect(rectStart, MARGIN_TOP, rectWidth, RECT_HEIGHT);
+        ctx.fillRect(rectStart, MARGIN_TOP, rectWidth,
+          (RECT_HEIGHT * this.trackState.scaleMultiplier));
       }
 
       // Don't render text when we have less than 5px to play with.
@@ -333,15 +339,24 @@ class CpuSliceTrack extends Track<Config, Data> {
       const right = Math.min(visWindowEndPx, rectEnd);
       const left = Math.max(rectStart, 0);
       const visibleWidth = Math.max(right - left, 1);
-      title = cropText(title, charWidth, visibleWidth);
-      subTitle = cropText(subTitle, charWidth, visibleWidth);
+
       const rectXCenter = left + visibleWidth / 2;
       ctx.fillStyle = '#fff';
-      ctx.font = '12px Roboto Condensed';
-      ctx.fillText(title, rectXCenter, MARGIN_TOP + RECT_HEIGHT / 2 - 1);
+      ctx.font = mainTextSize + 'px Roboto Condensed';
+      title = cropText(title,
+        charWidth,
+        visibleWidth);
+      ctx.fillText(title, rectXCenter,
+        MARGIN_TOP + (RECT_HEIGHT*this.trackState.scaleMultiplier/2));
       ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
-      ctx.font = '10px Roboto Condensed';
-      ctx.fillText(subTitle, rectXCenter, MARGIN_TOP + RECT_HEIGHT / 2 + 9);
+      ctx.font = subTextSize + 'px Roboto Condensed';
+      subTitle = cropText(subTitle,
+        charWidth,
+        visibleWidth);
+      ctx.fillText(subTitle, rectXCenter,
+        MARGIN_TOP +
+        (RECT_HEIGHT*this.trackState.scaleMultiplier/2) +
+        subTextSize);
     }
 
     const selection = globals.state.currentSelection;
@@ -361,7 +376,8 @@ class CpuSliceTrack extends Track<Config, Data> {
         ctx.strokeStyle = `hsl(${color.h}, ${color.s}%, 30%)`;
         ctx.beginPath();
         ctx.lineWidth = 3;
-        ctx.strokeRect(rectStart, MARGIN_TOP - 1.5, rectWidth, RECT_HEIGHT + 3);
+        ctx.strokeRect(rectStart, MARGIN_TOP - 1.5, rectWidth,
+          (RECT_HEIGHT * this.trackState.scaleMultiplier) + 3);
         ctx.closePath();
         // Draw arrow from wakeup time of current slice.
         if (details.wakeupTs) {
@@ -370,7 +386,7 @@ class CpuSliceTrack extends Track<Config, Data> {
           drawDoubleHeadedArrow(
               ctx,
               wakeupPos,
-              MARGIN_TOP + RECT_HEIGHT,
+              MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier),
               latencyWidth,
               latencyWidth >= 20,
               2,
@@ -383,7 +399,8 @@ class CpuSliceTrack extends Track<Config, Data> {
             ctx.fillStyle = getCssStr('--main-background-color');
             ctx.fillRect(
                 wakeupPos + latencyWidth / 2 - measured.width / 2 - 1,
-                MARGIN_TOP + RECT_HEIGHT - 12,
+                MARGIN_TOP +
+                  (RECT_HEIGHT * this.trackState.scaleMultiplier) - 12,
                 measured.width + 2,
                 11);
             ctx.textBaseline = 'bottom';
@@ -391,7 +408,8 @@ class CpuSliceTrack extends Track<Config, Data> {
             ctx.fillText(
                 displayText,
                 wakeupPos + (latencyWidth) / 2,
-                MARGIN_TOP + RECT_HEIGHT - 1);
+                MARGIN_TOP +
+                  (RECT_HEIGHT * this.trackState.scaleMultiplier) - 1);
           }
         }
       }
@@ -401,11 +419,15 @@ class CpuSliceTrack extends Track<Config, Data> {
         const wakeupPos =
             Math.floor(visibleTimeScale.tpTimeToPx(details.wakeupTs));
         ctx.beginPath();
-        ctx.moveTo(wakeupPos, MARGIN_TOP + RECT_HEIGHT / 2 + 8);
+        ctx.moveTo(wakeupPos, MARGIN_TOP +
+          (RECT_HEIGHT * this.trackState.scaleMultiplier) / 2 + 8);
         ctx.fillStyle = getCssStr('--main-foreground-color');
-        ctx.lineTo(wakeupPos + 6, MARGIN_TOP + RECT_HEIGHT / 2);
-        ctx.lineTo(wakeupPos, MARGIN_TOP + RECT_HEIGHT / 2 - 8);
-        ctx.lineTo(wakeupPos - 6, MARGIN_TOP + RECT_HEIGHT / 2);
+        ctx.lineTo(wakeupPos + 6, MARGIN_TOP +
+          (RECT_HEIGHT * this.trackState.scaleMultiplier) / 2);
+        ctx.lineTo(wakeupPos, MARGIN_TOP +
+          (RECT_HEIGHT * this.trackState.scaleMultiplier) / 2 - 8);
+        ctx.lineTo(wakeupPos - 6, MARGIN_TOP +
+          (RECT_HEIGHT * this.trackState.scaleMultiplier) / 2);
         ctx.fill();
         ctx.closePath();
       }
@@ -428,7 +450,8 @@ class CpuSliceTrack extends Track<Config, Data> {
     this.mousePos = pos;
     if (data === undefined) return;
     const {visibleTimeScale} = globals.frontendLocalState;
-    if (pos.y < MARGIN_TOP || pos.y > MARGIN_TOP + RECT_HEIGHT) {
+    if (pos.y < MARGIN_TOP ||
+        pos.y > MARGIN_TOP + (RECT_HEIGHT * this.trackState.scaleMultiplier)) {
       this.utidHoveredInThisTrack = -1;
       globals.dispatch(Actions.setHoveredUtidAndPid({utid: -1, pid: -1}));
       return;

--- a/ui/src/tracks/null_track/index.ts
+++ b/ui/src/tracks/null_track/index.ts
@@ -21,7 +21,7 @@ export class NullTrack extends Track {
   static readonly kind = NULL_TRACK_KIND;
   constructor(args: NewTrackArgs) {
     super(args);
-    this.supportsEnhancing = true;
+    this.supportsResizing = true;
     this.frontendOnly = true;
   }
 
@@ -30,7 +30,7 @@ export class NullTrack extends Track {
   }
 
   getHeight(): number {
-    return 30*this.trackState.scaleMultiplier;
+    return 30 * this.trackState.scaleFactor;
   }
 
   renderCanvas(_: CanvasRenderingContext2D): void {}

--- a/ui/src/tracks/null_track/index.ts
+++ b/ui/src/tracks/null_track/index.ts
@@ -21,6 +21,7 @@ export class NullTrack extends Track {
   static readonly kind = NULL_TRACK_KIND;
   constructor(args: NewTrackArgs) {
     super(args);
+    this.supportsEnhancing = true;
     this.frontendOnly = true;
   }
 
@@ -29,7 +30,7 @@ export class NullTrack extends Track {
   }
 
   getHeight(): number {
-    return 30;
+    return 30*this.trackState.scaleMultiplier;
   }
 
   renderCanvas(_: CanvasRenderingContext2D): void {}

--- a/ui/src/tracks/process_scheduling/index.ts
+++ b/ui/src/tracks/process_scheduling/index.ts
@@ -179,7 +179,6 @@ class ProcessSchedulingTrackController extends TrackController<Config, Data> {
 
 const MARGIN_TOP = 5;
 const RECT_HEIGHT = 30;
-const TRACK_HEIGHT = MARGIN_TOP * 2 + RECT_HEIGHT;
 
 class ProcessSchedulingTrack extends Track<Config, Data> {
   static readonly kind = PROCESS_SCHEDULING_TRACK_KIND;
@@ -192,10 +191,11 @@ class ProcessSchedulingTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
+    this.supportsEnhancing =true;
   }
 
   getHeight(): number {
-    return TRACK_HEIGHT;
+    return MARGIN_TOP * 2 + (RECT_HEIGHT * this.trackState.scaleMultiplier);
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D): void {
@@ -230,7 +230,8 @@ class ProcessSchedulingTrack extends Track<Config, Data> {
     const [, rawEndIdx] = searchSegment(data.starts, endTime);
     const endIdx = rawEndIdx === -1 ? data.starts.length : rawEndIdx;
 
-    const cpuTrackHeight = Math.floor(RECT_HEIGHT / data.maxCpu);
+    const cpuTrackHeight =
+      Math.floor(RECT_HEIGHT * this.trackState.scaleMultiplier / data.maxCpu);
 
     for (let i = startIdx; i < endIdx; i++) {
       const tStart = data.starts[i];
@@ -283,13 +284,15 @@ class ProcessSchedulingTrack extends Track<Config, Data> {
     const data = this.data();
     this.mousePos = pos;
     if (data === undefined) return;
-    if (pos.y < MARGIN_TOP || pos.y > MARGIN_TOP + RECT_HEIGHT) {
+    if (pos.y < MARGIN_TOP || pos.y >
+        MARGIN_TOP + (RECT_HEIGHT* this.trackState.scaleMultiplier)) {
       this.utidHoveredInThisTrack = -1;
       globals.dispatch(Actions.setHoveredUtidAndPid({utid: -1, pid: -1}));
       return;
     }
 
-    const cpuTrackHeight = Math.floor(RECT_HEIGHT / data.maxCpu);
+    const cpuTrackHeight =
+      Math.floor(RECT_HEIGHT * this.trackState.scaleMultiplier / data.maxCpu);
     const cpu = Math.floor((pos.y - MARGIN_TOP) / (cpuTrackHeight + 1));
     const {visibleTimeScale} = globals.frontendLocalState;
     const t = visibleTimeScale.pxToHpTime(pos.x).toTPTime('floor');

--- a/ui/src/tracks/process_scheduling/index.ts
+++ b/ui/src/tracks/process_scheduling/index.ts
@@ -191,11 +191,11 @@ class ProcessSchedulingTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
-    this.supportsEnhancing =true;
+    this.supportsResizing =true;
   }
 
   getHeight(): number {
-    return MARGIN_TOP * 2 + (RECT_HEIGHT * this.trackState.scaleMultiplier);
+    return MARGIN_TOP * 2 + (RECT_HEIGHT * this.trackState.scaleFactor);
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D): void {
@@ -231,7 +231,7 @@ class ProcessSchedulingTrack extends Track<Config, Data> {
     const endIdx = rawEndIdx === -1 ? data.starts.length : rawEndIdx;
 
     const cpuTrackHeight =
-      Math.floor(RECT_HEIGHT * this.trackState.scaleMultiplier / data.maxCpu);
+      Math.floor(RECT_HEIGHT * this.trackState.scaleFactor / data.maxCpu);
 
     for (let i = startIdx; i < endIdx; i++) {
       const tStart = data.starts[i];
@@ -285,14 +285,14 @@ class ProcessSchedulingTrack extends Track<Config, Data> {
     this.mousePos = pos;
     if (data === undefined) return;
     if (pos.y < MARGIN_TOP || pos.y >
-        MARGIN_TOP + (RECT_HEIGHT* this.trackState.scaleMultiplier)) {
+        MARGIN_TOP + (RECT_HEIGHT* this.trackState.scaleFactor)) {
       this.utidHoveredInThisTrack = -1;
       globals.dispatch(Actions.setHoveredUtidAndPid({utid: -1, pid: -1}));
       return;
     }
 
     const cpuTrackHeight =
-      Math.floor(RECT_HEIGHT * this.trackState.scaleMultiplier / data.maxCpu);
+      Math.floor(RECT_HEIGHT * this.trackState.scaleFactor / data.maxCpu);
     const cpu = Math.floor((pos.y - MARGIN_TOP) / (cpuTrackHeight + 1));
     const {visibleTimeScale} = globals.frontendLocalState;
     const t = visibleTimeScale.pxToHpTime(pos.x).toTPTime('floor');

--- a/ui/src/tracks/thread_state/index.ts
+++ b/ui/src/tracks/thread_state/index.ts
@@ -160,7 +160,7 @@ class ThreadStateTrackController extends TrackController<Config, Data> {
 }
 
 const MARGIN_TOP = 3;
-const RECT_HEIGHT = 12;
+const RECT_HEIGHT = 18;
 const EXCESS_WIDTH = 10;
 
 class ThreadStateTrack extends Track<Config, Data> {
@@ -171,10 +171,11 @@ class ThreadStateTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
+    this.supportsEnhancing = true;
   }
 
   getHeight(): number {
-    return 2 * MARGIN_TOP + RECT_HEIGHT;
+    return 2 * MARGIN_TOP + RECT_HEIGHT * this.trackState.scaleMultiplier;
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D): void {
@@ -184,6 +185,9 @@ class ThreadStateTrack extends Track<Config, Data> {
       windowSpan,
     } = globals.frontendLocalState;
     const data = this.data();
+    ctx.font =
+      Math.floor(RECT_HEIGHT * this.trackState.scaleMultiplier * (2 / 3)) +
+      'px Roboto Condensed';
     const charWidth = ctx.measureText('dbpqaouk').width / 8;
 
     if (data === undefined) return;  // Can't possibly draw anything.
@@ -202,7 +206,6 @@ class ThreadStateTrack extends Track<Config, Data> {
     );
 
     ctx.textAlign = 'center';
-    ctx.font = '10px Roboto Condensed';
 
     for (let i = 0; i < data.starts.length; i++) {
       // NOTE: Unlike userspace and scheduling slices, thread state slices are
@@ -240,14 +243,22 @@ class ThreadStateTrack extends Track<Config, Data> {
       }
       ctx.fillStyle = colorStr;
 
-      ctx.fillRect(rectStart, MARGIN_TOP, rectWidth, RECT_HEIGHT);
+      ctx.fillRect(
+        rectStart,
+        MARGIN_TOP,
+        rectWidth,
+        RECT_HEIGHT * this.trackState.scaleMultiplier,
+        );
 
       // Don't render text when we have less than 10px to play with.
       if (rectWidth < 10 || state === 'Sleeping') continue;
       const title = cropText(state, charWidth, rectWidth);
       const rectXCenter = rectStart + rectWidth / 2;
       ctx.fillStyle = color.l > 80 ? '#404040' : '#fff';
-      ctx.fillText(title, rectXCenter, MARGIN_TOP + RECT_HEIGHT / 2 + 3);
+      ctx.fillText(
+        title,
+        rectXCenter,
+        MARGIN_TOP + RECT_HEIGHT * this.trackState.scaleMultiplier * (2 / 3));
 
       if (isSelected) {
         drawRectOnSelected = () => {
@@ -263,7 +274,7 @@ class ThreadStateTrack extends Track<Config, Data> {
               rectStart,
               MARGIN_TOP - 1.5,
               rectEnd - rectStart,
-              RECT_HEIGHT + 3);
+              RECT_HEIGHT * this.trackState.scaleMultiplier + 3);
           ctx.closePath();
         };
       }

--- a/ui/src/tracks/thread_state/index.ts
+++ b/ui/src/tracks/thread_state/index.ts
@@ -171,11 +171,11 @@ class ThreadStateTrack extends Track<Config, Data> {
 
   constructor(args: NewTrackArgs) {
     super(args);
-    this.supportsEnhancing = true;
+    this.supportsResizing = true;
   }
 
   getHeight(): number {
-    return 2 * MARGIN_TOP + RECT_HEIGHT * this.trackState.scaleMultiplier;
+    return 2 * MARGIN_TOP + RECT_HEIGHT * this.trackState.scaleFactor;
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D): void {
@@ -186,7 +186,7 @@ class ThreadStateTrack extends Track<Config, Data> {
     } = globals.frontendLocalState;
     const data = this.data();
     ctx.font =
-      Math.floor(RECT_HEIGHT * this.trackState.scaleMultiplier * (2 / 3)) +
+      Math.floor(RECT_HEIGHT * this.trackState.scaleFactor * 2 / 3) +
       'px Roboto Condensed';
     const charWidth = ctx.measureText('dbpqaouk').width / 8;
 
@@ -247,7 +247,7 @@ class ThreadStateTrack extends Track<Config, Data> {
         rectStart,
         MARGIN_TOP,
         rectWidth,
-        RECT_HEIGHT * this.trackState.scaleMultiplier,
+        RECT_HEIGHT * this.trackState.scaleFactor,
         );
 
       // Don't render text when we have less than 10px to play with.
@@ -258,7 +258,7 @@ class ThreadStateTrack extends Track<Config, Data> {
       ctx.fillText(
         title,
         rectXCenter,
-        MARGIN_TOP + RECT_HEIGHT * this.trackState.scaleMultiplier * (2 / 3));
+        MARGIN_TOP + RECT_HEIGHT * this.trackState.scaleFactor * 2 / 3);
 
       if (isSelected) {
         drawRectOnSelected = () => {
@@ -274,7 +274,7 @@ class ThreadStateTrack extends Track<Config, Data> {
               rectStart,
               MARGIN_TOP - 1.5,
               rectEnd - rectStart,
-              RECT_HEIGHT * this.trackState.scaleMultiplier + 3);
+              RECT_HEIGHT * this.trackState.scaleFactor + 3);
           ctx.closePath();
         };
       }


### PR DESCRIPTION
Issac from Google brought up a use case where the user may want to give a Perfetto track more vertical space for investigating values at a more precise level. 

How this could be built upon:
Most / all tracks I have in my Perfetto captures are supporting "enhancement" (changing track height).  TrackGroups also have this functionality as long as the summary track supports it.  To change scale click and drag the bottom of the track /trackGroup's shell.  Cursor will change when hovered over the applicable area.