### PR TITLE
Don't show drop border if unable to move trackLike to location [Issue 664]

### DIFF
--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -213,7 +213,7 @@ export class TrackGroupPanel extends Panel<Attrs> {
     e.stopPropagation();
     globals.rafScheduler.scheduleFullRedraw();
     dataTransfer.effectAllowed = 'move';
-    dataTransfer.setData('perfetto/track', `${this.trackGroupId}`);
+    dataTransfer.setData('perfetto/track/' + this.trackGroupId, `${this.trackGroupId}`);
     dataTransfer.setDragImage(new Image(), 0, 0);
   }
 
@@ -227,17 +227,35 @@ export class TrackGroupPanel extends Panel<Attrs> {
     if (!(e.target instanceof HTMLElement)) return;
     const dataTransfer = e.dataTransfer;
     if (dataTransfer === null) return;
-    if (!dataTransfer.types.includes('perfetto/track')) return;
+    const dataType = dataTransfer.types.find((dataType)=>{
+      if (dataType.startsWith('perfetto/track/')) {
+        return true;
+      }
+      return false;
+    });
+    if (!dataType) return;
+    const trackLikeId = dataType.split('/').pop();
+    if (!trackLikeId) return;
     e.stopPropagation();
     dataTransfer.dropEffect = 'move';
     e.preventDefault();
 
-    // Apply some hysteresis to the drop logic so that the lightened border
-    // changes only when we get close enough to the border.
-    if (e.offsetY < e.target.scrollHeight / 3) {
-      this.dropping = 'before';
-    } else if (e.offsetY > e.target.scrollHeight / 3 * 2) {
-      this.dropping = 'after';
+    // Test if id has same parent as current
+    // If no do not set this.dropping
+    let trackLike : TrackState | TrackGroupState =
+      globals.state.trackGroups[trackLikeId];
+    if (!trackLike) {
+      trackLike = globals.state.tracks[trackLikeId];
+    }
+    if (('trackGroup' in trackLike && this.trackGroupState.parentGroup === trackLike.trackGroup) ||
+      'parentGroup' in trackLike && this.trackGroupState.parentGroup === trackLike.parentGroup) {
+      // Apply some hysteresis to the drop logic so that the lightened border
+      // changes only when we get close enough to the border.
+      if (e.offsetY < e.target.scrollHeight / 3) {
+        this.dropping = 'before';
+      } else if (e.offsetY > e.target.scrollHeight / 3 * 2) {
+        this.dropping = 'after';
+      }
     }
     globals.rafScheduler.scheduleFullRedraw();
   }
@@ -252,7 +270,15 @@ export class TrackGroupPanel extends Panel<Attrs> {
     const dataTransfer = e.dataTransfer;
     if (dataTransfer === null) return;
     globals.rafScheduler.scheduleFullRedraw();
-    const srcId = dataTransfer.getData('perfetto/track');
+    const dataType = dataTransfer.types.find((dataType)=>{
+      if (dataType.startsWith('perfetto/track/')) {
+        return true;
+      }
+      return false;
+    });
+    if (!dataType) return;
+    const srcId = dataType.split('/').pop();
+    if (!srcId) return;
     const dstId = this.trackGroupId;
     globals.dispatch(Actions.moveTrack({srcId, op: this.dropping, dstId}));
     this.dropping = undefined;

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -16,7 +16,7 @@ import {hex} from 'color-convert';
 import m from 'mithril';
 
 import {Actions} from '../common/actions';
-import {TrackState} from '../common/state';
+import {TrackGroupState, TrackState} from '../common/state';
 import {TPTime} from '../common/time';
 
 import {TRACK_SHELL_WIDTH, getCssStr} from './css_constants';
@@ -167,7 +167,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
     e.stopPropagation();
     globals.rafScheduler.scheduleFullRedraw();
     dataTransfer.effectAllowed = 'move';
-    dataTransfer.setData('perfetto/track', `${this.attrs!.trackState.id}`);
+    dataTransfer.setData('perfetto/track/'+this.attrs!.trackState.id, `${this.attrs!.trackState.id}`);
     dataTransfer.setDragImage(new Image(), 0, 0);
   }
 
@@ -181,17 +181,35 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
     if (!(e.target instanceof HTMLElement)) return;
     const dataTransfer = e.dataTransfer;
     if (dataTransfer === null) return;
-    if (!dataTransfer.types.includes('perfetto/track')) return;
+    const dataType = dataTransfer.types.find((dataType)=>{
+      if (dataType.startsWith('perfetto/track/')) {
+        return true;
+      }
+      return false;
+    });
+    if (!dataType) return;
+    const trackLikeId = dataType.split('/').pop();
+    if (!trackLikeId) return;
     e.stopPropagation();
     dataTransfer.dropEffect = 'move';
     e.preventDefault();
 
-    // Apply some hysteresis to the drop logic so that the lightened border
-    // changes only when we get close enough to the border.
-    if (e.offsetY < e.target.scrollHeight / 3) {
-      this.dropping = 'before';
-    } else if (e.offsetY > e.target.scrollHeight / 3 * 2) {
-      this.dropping = 'after';
+    // Test if id has same parent as current
+    // If no do not set this.dropping
+    let trackLike : TrackState | TrackGroupState =
+      globals.state.trackGroups[trackLikeId];
+    if (!trackLike) {
+      trackLike = globals.state.tracks[trackLikeId];
+    }
+    if (('trackGroup' in trackLike && this.attrs!.trackState.trackGroup === trackLike.trackGroup) ||
+    'parentGroup' in trackLike && this.attrs!.trackState.trackGroup === trackLike.parentGroup) {
+      // Apply some hysteresis to the drop logic so that the lightened border
+      // changes only when we get close enough to the border.
+      if (e.offsetY < e.target.scrollHeight / 3) {
+        this.dropping = 'before';
+      } else if (e.offsetY > e.target.scrollHeight / 3 * 2) {
+        this.dropping = 'after';
+      }
     }
     globals.rafScheduler.scheduleFullRedraw();
   }
@@ -206,7 +224,15 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
     const dataTransfer = e.dataTransfer;
     if (dataTransfer === null) return;
     globals.rafScheduler.scheduleFullRedraw();
-    const srcId = dataTransfer.getData('perfetto/track');
+    const dataType = dataTransfer.types.find((dataType)=>{
+      if (dataType.startsWith('perfetto/track/')) {
+        return true;
+      }
+      return false;
+    });
+    if (!dataType) return;
+    const srcId = dataType.split('/').pop();
+    if (!srcId) return;
     const dstId = this.attrs!.trackState.id;
     globals.dispatch(Actions.moveTrack({srcId, op: this.dropping, dstId}));
     this.dropping = undefined;


### PR DESCRIPTION
[Sokatoa Issue](https://github.com/android-graphics/sokatoa/issues/664)
Since the data is not available from the DataTransfer object on dragover and the data is just an id, the "format" of the DataTransfer  will now be "perfetto/track/[insert id here] rather than "perfetto/track" with an id in the object.

The end result of this is the blue border that signifies the track movement, will now only show if the movement will be successful.
