### PR TITLE
Add some exceptions to a hack in Perfetto Issue 528

### DIFF
--- a/ui/src/controller/record_controller.ts
+++ b/ui/src/controller/record_controller.ts
@@ -129,7 +129,8 @@ export function toPbtxt(configBuffer: Uint8Array): string {
         value.startsWith('STAT_') || value.startsWith('LID_') ||
         value.startsWith('BATTERY_COUNTER_') || value === 'DISCARD' ||
         value === 'RING_BUFFER' || value === 'BACKGROUND' ||
-        value === 'USER_INITIATED';
+        value === 'USER_INITIATED' ||
+        value === 'START_TRACING';
   }
   // Since javascript doesn't have 64 bit numbers when converting protos to
   // json the proto library encodes them as strings. This is lossy since
@@ -144,6 +145,7 @@ export function toPbtxt(configBuffer: Uint8Array): string {
       'samplingIntervalBytes',
       'shmemSizeBytes',
       'timestampUnitMultiplier',
+      'counterPeriodNs',
     ].includes(key);
   }
   function* message(msg: {}, indent: number): IterableIterator<string> {


### PR DESCRIPTION
Perfetto has exceptions for some things in toPbText that caused things to not parse properly into a Perfetto config.  Future solution could use the data from the protos to replace this, but that will not be covered in this PR.

