### PR TITLE
Open a subset of a timeline

### DIFF
--- a/ui/src/common/high_precision_time.ts
+++ b/ui/src/common/high_precision_time.ts
@@ -265,6 +265,23 @@ export class HighPrecisionTimeSpan implements Span<HighPrecisionTime> {
     return !(x.end.lte(this.start) || x.start.gte(this.end));
   }
 
+  intersection(x: Span<HighPrecisionTime, HighPrecisionTime>): Span<HighPrecisionTime, HighPrecisionTime> {
+    if (x.start.lte(this.start) && x.end.gte(this.end)) {
+      // I am the intersection
+      return this;
+    }
+    if (x.start.gte(this.start) && x.end.lte(this.end)) {
+      // It is the intersection
+      return x;
+    }
+    if (x.end.lt(this.start) || this.end.lt(x.start)) {
+      // It's an empty intersection. [0, 0] is as good as any other span
+      return HighPrecisionTimeSpan.ZERO;
+    }
+    return new HighPrecisionTimeSpan(HighPrecisionTime.max(this.start, x.start),
+      HighPrecisionTime.min(x.end, this.end));
+  }
+
   add(time: HighPrecisionTime): Span<HighPrecisionTime> {
     return new HighPrecisionTimeSpan(this.start.add(time), this.end.add(time));
   }

--- a/ui/src/common/high_precision_time_unittest.ts
+++ b/ui/src/common/high_precision_time_unittest.ts
@@ -323,4 +323,17 @@ describe('HighPrecisionTimeSpan', () => {
     expect(x.intersects(mkSpan('20', '30'))).toBeFalsy();
     expect(x.intersects(mkSpan('5', '25'))).toBeTruthy();
   });
+
+  it('creates intersection of spans', () => {
+    const x = mkSpan('10', '20');
+
+    expect(x.intersection(mkSpan('0', '10'))).toEqual(mkSpan('10', '10'));
+    expect(x.intersection(mkSpan('5', '15'))).toEqual(mkSpan('10', '15'));
+    expect(x.intersection(mkSpan('12', '18'))).toEqual(mkSpan('12', '18'));
+    expect(x.intersection(mkSpan('15', '25'))).toEqual(mkSpan('15', '20'));
+    expect(x.intersection(mkSpan('20', '30'))).toEqual(mkSpan('20', '20'));
+    expect(x.intersection(mkSpan('5', '25'))).toEqual(mkSpan('10', '20'));
+    expect(x.intersection(mkSpan('2', '8'))).toEqual(mkSpan('0', '0'));
+    expect(x.intersection(mkSpan('22', '28'))).toEqual(mkSpan('0', '0'));
+  });
 });

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -365,6 +365,7 @@ export class TraceController extends Controller<States> {
             Actions.setEngineFailed({mode: 'HTTP_RPC', failure: `${err}`}));
         throw err;
       };
+      engine.timelineConstraint = globals.timelineSubsetRange;
       globals.httpRpcEngineCustomizer?.(engine);
     } else {
       console.log('Opening trace using built-in WASM engine');
@@ -377,6 +378,7 @@ export class TraceController extends Controller<States> {
         ingestFtraceInRawTable: INGEST_FTRACE_IN_RAW_TABLE_FLAG.get(),
         analyzeTraceProtoContent: ANALYZE_TRACE_PROTO_CONTENT_FLAG.get(),
       });
+      engine.timelineConstraint = globals.timelineSubsetRange;
     }
     this.engine = engine;
 

--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -287,6 +287,7 @@ class Globals {
   private _promptToLoadFromTraceProcessorShell = true;
   private _trackFilteringEnabled = false;
   private _engineReadyObservers: ((engine: EngineConfig) => void)[] = [];
+  private _timelineSubsetRange?: Span<TPTime, TPDuration> = undefined;
 
 
   // Init from session storage since correct value may be required very early on
@@ -736,6 +737,20 @@ class Globals {
 
   addEngineReadyObserver(observer: (engine: EngineConfig) => void): void {
       this._engineReadyObservers.push(observer);
+  }
+
+  /**
+   * Obtain a range of timestamps to which the entire timeline is restricted.
+   */
+  get timelineSubsetRange(): Span<TPTime, TPDuration> | undefined {
+    return this._timelineSubsetRange;
+  }
+
+  /**
+   * Set or clear the range of timestamps to which the entire timeline is restricted.
+   */
+  set timelineSubsetRange(timeSpan: Span<TPTime, TPDuration> | undefined) {
+    this._timelineSubsetRange = timeSpan;
   }
 
   makeSelection(action: DeferredAction<{}>, tabToOpen = 'current_selection') {

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -51,6 +51,7 @@ import {TraceInfoPage} from './trace_info_page';
 import {maybeOpenTraceFromRoute} from './trace_url_handler';
 import {ViewerPage} from './viewer_page';
 import {WidgetsPage} from './widgets_page';
+import {TPTimeSpan, tpTimeFromSql} from '../common/time';
 
 export {ViewerPage} from './viewer_page';
 export {globals} from './globals';
@@ -145,9 +146,18 @@ function setExtensionAvailability(available: boolean) {
 }
 
 function initGlobalsFromQueryString() {
-  const queryString = window.location.search;
-  globals.embeddedMode = queryString.includes('mode=embedded');
-  globals.hideSidebar = queryString.includes('hideSidebar=true');
+  const queryString = new URLSearchParams(window.location.search);
+  globals.embeddedMode = queryString.get('mode') === 'embedded';
+  globals.hideSidebar = queryString.get('hideSidebar') === 'true';
+  const startTs = queryString.get('startTs');
+  const endTs = queryString.get('endTs');
+  if (startTs && endTs) {
+    try {
+      globals.timelineSubsetRange = new TPTimeSpan(tpTimeFromSql(startTs), tpTimeFromSql(endTs));
+    } catch (error) {
+      console.error('Invalid timeline subset range.', error);
+    }
+  }
 }
 
 function defaultContentSecurityPolicy(): string {


### PR DESCRIPTION
Add support for 'startTs' and 'endTs' URL parameters to open a narrow window of time in Perfetto as though it were the entire trace.
