### PR TITLE
Render annotation flags over track group headers

### DIFF
--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -308,7 +308,16 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
   }
 }
 
-export interface TrackContentAttrs { track: Track; }
+export interface TrackContentAttrs {
+  track: Track;
+  /** Optional tag name to instantiate instead of the default `<div>`. */
+  tagname?: keyof HTMLElementTagNameMap;
+  /**
+   * Optional attributes to add to the track content element, especially
+   * when using the custom `tagname`.
+   */
+  attrs?: m.Attributes;
+}
 export class TrackContent implements m.ClassComponent<TrackContentAttrs> {
   private mouseDownX?: number;
   private mouseDownY?: number;
@@ -317,8 +326,9 @@ export class TrackContent implements m.ClassComponent<TrackContentAttrs> {
   view(node: m.CVnode<TrackContentAttrs>) {
     const attrs = node.attrs;
     return m(
-        '.track-content',
+        `${attrs.tagname ?? ''}.track-content`,
         {
+          ...(attrs.attrs ?? {}),
           onmousemove: (e: PerfettoMouseEvent) => {
             attrs.track.onMouseMove(
                 {x: e.layerX - TRACK_SHELL_WIDTH, y: e.layerY});


### PR DESCRIPTION
All track rendering was done on a big scrolling canvas element that sits behind the track dividing lines and shells. That is fine for rendering stuff in the track content area of the scrolling tracks, but the track content area of the headers of expanded groups does not scroll with the rest. They're not even a part of the same static layout, instead being positioned relatively and moreover sticking to the top of the panel as tracks scroll up beneath them. Because they are in a different layout to the canvas, they occlude anything painted on the canvas, so painting in the expanded group headers has no effect.

Consequently, it is necessary to give each expanded group header its own canvas on which we can draw content such as the stems of note flags.

![CleanShot 2024-02-28 at 12 57 14](https://github.com/android-graphics/sokatoa/assets/1615558/1f3d0de6-054f-4ca7-91c8-7ce8b9dcf284)
