### PR TITLE
Rework timeline subset range as an async callback function

### DIFF
--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -365,7 +365,6 @@ export class TraceController extends Controller<States> {
             Actions.setEngineFailed({mode: 'HTTP_RPC', failure: `${err}`}));
         throw err;
       };
-      engine.timelineConstraint = globals.timelineSubsetRange;
       globals.httpRpcEngineCustomizer?.(engine);
     } else {
       console.log('Opening trace using built-in WASM engine');
@@ -378,7 +377,6 @@ export class TraceController extends Controller<States> {
         ingestFtraceInRawTable: INGEST_FTRACE_IN_RAW_TABLE_FLAG.get(),
         analyzeTraceProtoContent: ANALYZE_TRACE_PROTO_CONTENT_FLAG.get(),
       });
-      engine.timelineConstraint = globals.timelineSubsetRange;
     }
     this.engine = engine;
 
@@ -442,6 +440,8 @@ export class TraceController extends Controller<States> {
     // traceUuid will be '' if the trace is not cacheable (URL or RPC).
     const traceUuid = await this.cacheCurrentTrace();
 
+    const clamp = await globals.timelineSubsetRange?.(this.engine);
+    this.engine.timelineConstraint = clamp;
     const traceTime = await this.engine.getTraceTimeBounds();
     const start = traceTime.start;
     const end = traceTime.end;

--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -205,6 +205,12 @@ export interface VsyncData {
   toggleTs: bigint[];
 }
 
+/**
+ * An asynchronous function that provides a timespan.
+ */
+export type TimespanProvider =
+  (engine: Engine) => Promise<Span<TPTime, TPDuration>> | undefined;
+
 function getRoot() {
   // Works out the root directory where the content should be served from
   // e.g. `http://origin/v1.2.3/`.
@@ -287,7 +293,7 @@ class Globals {
   private _promptToLoadFromTraceProcessorShell = true;
   private _trackFilteringEnabled = false;
   private _engineReadyObservers: ((engine: EngineConfig) => void)[] = [];
-  private _timelineSubsetRange?: Span<TPTime, TPDuration> = undefined;
+  private _timelineSubsetRange?: TimespanProvider = undefined;
 
 
   // Init from session storage since correct value may be required very early on
@@ -740,16 +746,20 @@ class Globals {
   }
 
   /**
-   * Obtain a range of timestamps to which the entire timeline is restricted.
+   * Obtain a provider of the range of timestamps to which the entire timeline
+   * is restricted.
    */
-  get timelineSubsetRange(): Span<TPTime, TPDuration> | undefined {
+  get timelineSubsetRange(): TimespanProvider | undefined {
     return this._timelineSubsetRange;
   }
 
   /**
-   * Set or clear the range of timestamps to which the entire timeline is restricted.
+   * Set or clear the provider of the range of timestamps to which the entire
+   * timeline is restricted.
+   * @param {TimespanProvider} timeSpan the timespan provider,
+   *   or none to clear it
    */
-  set timelineSubsetRange(timeSpan: Span<TPTime, TPDuration> | undefined) {
+  set timelineSubsetRange(timeSpan: TimespanProvider | undefined) {
     this._timelineSubsetRange = timeSpan;
   }
 

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -153,7 +153,8 @@ function initGlobalsFromQueryString() {
   const endTs = queryString.get('endTs');
   if (startTs && endTs) {
     try {
-      globals.timelineSubsetRange = new TPTimeSpan(tpTimeFromSql(startTs), tpTimeFromSql(endTs));
+      const span = new TPTimeSpan(tpTimeFromSql(startTs), tpTimeFromSql(endTs));
+      globals.timelineSubsetRange = () => Promise.resolve(span);
     } catch (error) {
       console.error('Invalid timeline subset range.', error);
     }


### PR DESCRIPTION
It turns out that Sokatoa, when hosting Perfetto, needs to calculate frame-based timestamp ranges to constrain the Perfetto timeline from the slices in the Perfetto trace, itself. So they cannot be computed before opening the Perfetto app and it is necessary for Perfetto to call back into the host application, which then uses the Engine to query the trace database.
