### PR TITLE
Child Leaf Nodes weren't indented enough [Issue 1062]

### DIFF
--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -97,16 +97,15 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       }
     }
 
-    const depth = attrs.trackState.trackGroup === SCROLLING_TRACK_GROUP ?
+    const depth = (attrs.trackState.trackGroup === SCROLLING_TRACK_GROUP ?
       0 :
-      getContainingTrackIds(globals.state, attrs.trackState.id)?.length ?? 0;
+      getContainingTrackIds(globals.state, attrs.trackState.id)?.length ?? 0) +
+      1;
     const trackTitle = attrs.trackState.title ?? attrs.trackState.name;
     const titleStyling: Record<string, string|undefined> = {
       fontSize: getTitleSize(trackTitle),
     };
-    if (depth > 0) {
       titleStyling.marginLeft = `${depth/2}rem`;
-    }
 
     const dragClass = this.dragging ? `drag` : '';
     const dropClass = this.dropping ? `drop-${this.dropping}` : '';


### PR DESCRIPTION
[Sokatoa Issue](https://github.com/android-graphics/sokatoa/issues/1062)
Adds an extra indentation to child leaf nodes to make up for the offset from the collapsible button
![image](https://github.com/eclipsesource/perfetto/assets/121060410/9d04c7f2-b6f1-4e27-9ca3-f0977f3e9cae)