### PR TITLE
Don't scroll lines when pinning a track

### DIFF
--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -141,7 +141,18 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
           ...this.getTrackShellButtons(attrs),
           attrs.track.getContextMenu(),
           m(TrackButton, {
-            action: () => {
+            action: (e) => {
+              // Scroll timeline by height of toggledPinnedTrack
+              if (e.currentTarget && e.currentTarget instanceof Element) {
+                const trackShell = e.currentTarget.closest('.track-shell');
+                if (trackShell) {
+                  const parentScrollPanel = trackShell.closest('.scrolling-panel-container');
+                  if (parentScrollPanel) {
+                    parentScrollPanel.scroll(0,
+                      parentScrollPanel.scrollTop + trackShell.clientHeight);
+                  }
+                }
+              }
               globals.dispatch(
                   Actions.toggleTrackPinned({trackId: attrs.trackState.id}));
             },

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -143,13 +143,19 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
           m(TrackButton, {
             action: (e) => {
               // Scroll timeline by height of toggledPinnedTrack
+              const toBePinned =
+                !globals.state.pinnedTracks.includes(attrs.trackState.id);
               if (e.currentTarget && e.currentTarget instanceof Element) {
                 const trackShell = e.currentTarget.closest('.track-shell');
                 if (trackShell) {
+                  let toScroll = trackShell.clientHeight;
+                  if (!toBePinned) {
+                    toScroll *= -1;
+                  }
                   const parentScrollPanel = trackShell.closest('.scrolling-panel-container');
                   if (parentScrollPanel) {
                     parentScrollPanel.scroll(0,
-                      parentScrollPanel.scrollTop + trackShell.clientHeight);
+                      parentScrollPanel.scrollTop + toScroll);
                   }
                 }
               }


### PR DESCRIPTION
#### What it does
[Sokatoa Issue](https://github.com/android-graphics/sokatoa/issues/1053)
When a track is pinned we scroll up the track height to offset it being added the pinned container.

#### How to test
Pin a track.  If the timeline hasn't shifted downward it is working correctly. 

#### Media

https://github.com/eclipsesource/perfetto/assets/121060410/cded3fc2-35da-4659-84ef-a84a4d082d79