### PR TITLE
Change 'Remove track' to 'Hide track'

### DIFF
--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -389,9 +389,9 @@ export class TrackGroupPanel extends Panel<Attrs> {
             ]);
             e.stopPropagation();
           },
-          i: 'delete',
+          i: 'hide',
           disabled,
-          tooltip: 'Remove track group',
+          tooltip: 'Hide track group',
           showButton: false, // Only show on roll-over
           fullHeight: true,
         }));

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -290,8 +290,8 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
     result.push(m(TrackButton, {
       action: () => globals.dispatch(
         Actions.removeTrack({trackId: attrs.trackState.id})),
-      i: 'delete',
-      tooltip: 'Remove track',
+      i: 'hide',
+      tooltip: 'Hide track',
       showButton: false, // Only show on roll-over
       fullHeight: true,
       disabled: !this.canDeleteTrack(attrs.trackState),


### PR DESCRIPTION
With the upcoming introduction of user-defined tracks (e.g., the user combines one or more counter tracks into a single one), we need to adjust the existing removal track button. This button doesn't technically remove the track; it hides it. The track definition ends up in a filtered list, so that it can be reintroduced into the timeline by the user via the Track Filtering timeline toolbar button.

We also need to allow for a track removal that is a "true" removal. Such an action will do more than just hide the track. It will delete the track altogether. The user won't be able to un-hide it. This type of action will be available only to user defined tracks. The user can of course re-define the track from scratch to effectively re-introduce it into the timeline.

The existing button is being given a new tooltip and icon to better reflect the hiding nature. Additionally, the RemoveTrack action now supports a purge option for use in a true removal. In that case, we simply don't add the track definition to the filtered list. We'll use the garbage can icon for that action, and the tooltip will say "Delete user-defined track". Only user-defined tracks will have this action, and it will be added to the track by Sokatoa, as support for these user-defined tracks is entirely done within Sokatoa using perfetto plugins.

<!--
Thank you for your Pull Request. Please provide a description and review the requirements below.

***
Please make sure that you set 'eclipsesource/perfetto' as the base repository with 'reuse_timeline' as base branch for this pull request. By default, GitHub uses the upstream repository from Google as base repository but in 99% of the cases you'll want your contribution to go into this fork.
***

If you have discovered a security vulnerability in this project, please report it privately. Do not disclose it as a public issue. This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released. Please disclose it at https://github.com/eclipsesource/perfetto/security/advisories/new.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
