### PR TITLE
StickyTrackGroups now stack

### DIFF
--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -275,11 +275,14 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
   // Render a tree of panels into one vnode. Argument `path` is used to build
   // `key` attribute for intermediate tree vnodes: otherwise Mithril internals
   // will complain about keyed and non-keyed vnodes mixed together.
-  renderTree(node: AnyAttrsVnode, path: string): m.Vnode {
+  renderTree(
+      node: AnyAttrsVnode,
+      path: string,
+      depthObject: { depth:number } = {depth: 0}): m.Vnode {
     if (this.isTrackGroupAttrs(node.attrs)) {
-      // Set the top property to the recursive height of its parents
-      // *sarcasticlly* easy
       const top = this.getHeightOfParent(node.attrs.header.attrs.trackGroupId);
+      const children = node.attrs.childTracks.map(
+        (child, index) => this.renderTree(child, `${path}-${index}`, depthObject));
       return m(
         'div',
         {key: path},
@@ -288,9 +291,8 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
             `${path}-header`, !node.attrs.collapsed ?{
               'position': ' sticky',
               'top': top + 'px',
-              'z-index': '3',
-            }: {}), ...node.attrs.childTracks.map(
-              (child, index) => this.renderTree(child, `${path}-${index}`)));
+              'z-index': (++depthObject.depth) + 2,
+            }: {}), ...children);
       ;
     }
     return this.renderPanel(node, assertExists(node.key) as string);

--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -266,7 +266,6 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
         });
         const height = summaryTrackElement.getHeight();
         return this.getHeightOfParent(trackGroup?.parentGroup) + height;
-        // How do I get the height from a trackGroup's ID
       }
     }
     return 0;

--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -239,7 +239,10 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
     return (attrs as {collapsed?: boolean}).collapsed !== undefined;
   }
 
-  renderPanel(node: AnyAttrsVnode, key: string, style?: object): m.Vnode {
+  renderPanel(
+      node: AnyAttrsVnode,
+      key: string,
+      style?: Partial<CSSStyleDeclaration> ): m.Vnode {
     assertFalse(this.panelByKey.has(key));
     this.panelByKey.set(key, node);
 
@@ -250,6 +253,7 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
             [node, m('.debug-panel-border', {key: 'debug-panel-border'})] :
             node);
   }
+
   getHeightOfParent(id?: string):number {
     if (id && id !== SCROLLING_TRACK_GROUP) {
       const trackGroup = globals.state.trackGroups[id];
@@ -288,10 +292,10 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
         this.renderPanel(
             node.attrs.header,
             `${path}-header`, !node.attrs.collapsed ?{
-              'position': ' sticky',
+              'position': 'sticky',
               'top': top + 'px',
-              'z-index': (++depthObject.depth) + 2,
-            }: {}), ...children);
+              'zIndex': ((++depthObject.depth) + 2).toString(),
+            }: undefined), ...children);
       ;
     }
     return this.renderPanel(node, assertExists(node.key) as string);


### PR DESCRIPTION
#### What it does
[Sokatoa Issue](https://github.com/android-graphics/sokatoa/issues/1056)
This PR makes the sticky headers for open track groups not cover over each other 

#### How to test

1. Open a perfetto file
2. Increase track height on a parent track to be taller than child group
3. expand both, if not already expanded, track groups
4. Scroll till parent group is drawn behind child group
5.  If the parent trackGroup doesn't peek behind the child then its working as expected

### Media 
![image](https://github.com/eclipsesource/perfetto/assets/121060410/c87d55f4-b143-4776-aff2-10aa3137c654)
