### PR TITLE
Let plugin track provider specify a group path

### DIFF
--- a/ui/src/common/plugin_api.ts
+++ b/ui/src/common/plugin_api.ts
@@ -47,6 +47,15 @@ export interface TrackInfo {
   // Tracks of the same group name are collected into a group of that name.
   group?: string;
 
+  // SOKATOA: support specifying a sequence/hierarchy of groups, as an
+  // alternative to specifying just a single one. This way, the plugin
+  // can create a track in an arbitrarily nested group.
+  // This property is ignored if |group| is defined.
+  //
+  // All elements in the array are group names, never a group ID, not even
+  // a group ID constant (e.g., SCROLLING_TRACKS).
+  groups?: string[];
+
   // An opaque config for the track.
   config: {};
 }

--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -2477,16 +2477,24 @@ class TrackDecider {
 
   async addPluginTracks(): Promise<void> {
     const promises = pluginManager.findPotentialTracks(this.engine);
-    const groups = await Promise.all(promises);
+    const results = await Promise.all(promises);
 
     const grouperator = (track: TrackInfo): string => {
       if (track.group) {
         return this.lazyTrackGroup(track.group)();
       }
+      if (track.groups) {
+        let parentGroupIdProvider: LazyIdProvider | undefined = undefined;
+        for (const group of track.groups) {
+          parentGroupIdProvider = this.lazyTrackGroup(group, {lazyParentGroup: parentGroupIdProvider});
+        }
+        return parentGroupIdProvider!();
+      }
+
       return SCROLLING_TRACK_GROUP;
     };
 
-    for (const infos of groups) {
+    for (const infos of results) {
       for (const info of infos) {
         this.tracksToAdd.push({
           engineId: this.engineId,


### PR DESCRIPTION
Currently, a plugin's track provider is limited to contributing a track at the root of the timeline or within an arbitrarily named group at the root of the timeline. It can't create a track in an arbitrarily nested group. This commit adds that ability.

