### PR TITLE
GPU Counters should not be sorted alphabetically in the perfetto capture results

### DIFF
--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -616,7 +616,10 @@ export const StateActions = {
     const coll = new Intl.Collator([], {sensitivity: 'base', numeric: true});
     for (const group of Object.values(state.trackGroups)) {
       group.sortOrder.sort((a: string, b: string) => {
-        if (state.tracks[a] && state.tracks[b]) {
+        if (state.tracks[a] && state.tracks[b] &&
+          // Check if sort key for tracks are ThreadTrackSortKeys
+          ThreadTrackSortKey.is(state.tracks[a].trackSortKey) &&
+          ThreadTrackSortKey.is(state.tracks[b].trackSortKey)) {
           const aRank = getFullKey(a);
           const bRank = getFullKey(b);
           for (let i = 0; i < aRank.length; i++) {

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -163,8 +163,8 @@ export type ThreadTrackSortKey = {
 
 export namespace ThreadTrackSortKey {
   export function is(key: unknown): key is ThreadTrackSortKey {
-    return !!(typeof key === 'object' && key && 'utid' in key && 'priority' in key && typeof key.utid === 'number');
-}
+    return typeof key === 'object' && !!key && 'utid' in key && 'priority' in key && typeof key.utid === 'number';
+  }
 }
 
 // Sort key for all tracks: both thread-associated and non-thread associated.

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -161,6 +161,12 @@ export type ThreadTrackSortKey = {
   priority: InThreadTrackSortKey,
 }
 
+export namespace ThreadTrackSortKey {
+  export function is(key: unknown): key is ThreadTrackSortKey {
+    return !!(typeof key === 'object' && key && 'utid' in key && 'priority' in key && typeof key.utid === 'number');
+}
+}
+
 // Sort key for all tracks: both thread-associated and non-thread associated.
 export type TrackSortKey = PrimaryTrackSortKey|ThreadTrackSortKey;
 

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -526,7 +526,6 @@ export class TraceController extends Controller<States> {
       publishFtraceCounters(counters);
     }
 
-    globals.dispatch(Actions.sortThreadTracks({}));
     globals.dispatch(Actions.maybeExpandOnlyTrackGroup({}));
 
     await this.selectFirstHeapProfile();

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -526,6 +526,7 @@ export class TraceController extends Controller<States> {
       publishFtraceCounters(counters);
     }
 
+    globals.dispatch(Actions.sortThreadTracks({}));
     globals.dispatch(Actions.maybeExpandOnlyTrackGroup({}));
 
     await this.selectFirstHeapProfile();

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -547,7 +547,7 @@ async function globalTrackProvider(engine: EngineProxy): Promise<TrackInfo[]> {
       from gpu_counter_track
       where name != 'gpufreq'
     )
-    order by name
+    order by id
   `);
 
   // Add global or GPU counter tracks that are not bound to any pid/tid.


### PR DESCRIPTION
[Sokatoa Issue](https://github.com/android-graphics/sokatoa/issues/690)

#### What it does

Makes GPU Counter tracks no longer be sorted alphabetically
This will only affect new captures as timeline state is saved and loaded

#### How to test

Make a capture with GPU Counters and note the order you are shown upon configuring.  
Open the GPU Counters section in the timeline. 
If the ordering is the same it worked.
