### PR TITLE
Scroll overflow

### DIFF
--- a/ui/src/assets/trace_info_page.scss
+++ b/ui/src/assets/trace_info_page.scss
@@ -18,6 +18,7 @@
   padding: 0 20px;
 
   section {
+    overflow:auto;
     margin: 20px auto;
     max-width: 800px;
     font-size: 1rem;


### PR DESCRIPTION
#### What it does
[Sokatoa Issue](https://github.com/android-graphics/sokatoa/issues/1395)

No longer overflows out of parent 
![image](https://github.com/eclipsesource/perfetto/assets/121060410/446c8822-b72f-4690-8244-6d7bbd32dc32)

