### PR TITLE
On a pinned track resize, the mouse and the border being moved are dislocated

### DIFF
--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -62,7 +62,7 @@ export class TrackGroupPanel extends Panel<Attrs> {
   // in trackGroupState() below.
   private lastTrackGroupState: TrackGroupState;
 
-  private initialHeight?: number;
+  private defaultHeight?: number;
 
   constructor(protected attrs: m.CVnode<Attrs>) {
     super();
@@ -77,7 +77,8 @@ export class TrackGroupPanel extends Panel<Attrs> {
     this.lastTrackGroupState = assertExists(
       globals.state.trackGroups[this.trackGroupId]);
       if (this.summaryTrack) {
-        this.initialHeight = this.summaryTrack.getHeight();
+        this.defaultHeight =
+          this.summaryTrack.getHeight() / this.summaryTrackState.scaleFactor;
       }
   }
 
@@ -103,15 +104,15 @@ export class TrackGroupPanel extends Panel<Attrs> {
   resize = (e: MouseEvent): void => {
     e.stopPropagation();
     e.preventDefault();
-    if(!this.summaryTrack){
+    if (!this.summaryTrack) {
       return;
     }
-    let y = this.summaryTrack.getHeight()
+    let y = this.summaryTrack.getHeight();
     const mouseMoveEvent = (evMove: MouseEvent): void => {
       evMove.preventDefault();
       y += evMove.movementY;
-      if (this.attrs && this.initialHeight) {
-        const newMultiplier = y / this.initialHeight;
+      if (this.attrs && this.defaultHeight) {
+        const newMultiplier = y / this.defaultHeight;
         if (newMultiplier < 1) {
           this.summaryTrackState.scaleFactor = 1;
         } else {

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -191,9 +191,16 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
     }
     let y = this.attrs.track.getHeight();
     const mouseMoveEvent = (evMove: MouseEvent): void => {
+      if (!this.attrs) {
+        return;
+      }
       evMove.preventDefault();
-      y += evMove.movementY;
-        if (this.attrs && this.initialHeight) {
+      let movementY = evMove.movementY;
+      if (isPinned(this.attrs.trackState.id)) {
+        movementY /=2;
+      }
+      y += movementY;
+        if (this.initialHeight) {
           const newMultiplier = y / this.initialHeight;
           if (newMultiplier < 1) {
             this.attrs.trackState.scaleFactor = 1;

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -68,7 +68,7 @@ function isSelected(id: string) {
 interface TrackShellAttrs {
   track: Track;
   trackState: TrackState;
-  pinnedGroup?: boolean;
+  pinnedCopy?: boolean;
 }
 
 class TrackShell implements m.ClassComponent<TrackShellAttrs> {
@@ -198,7 +198,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       }
       evMove.preventDefault();
       let movementY = evMove.movementY;
-      if (this.attrs.pinnedGroup !== true &&
+      if (this.attrs.pinnedCopy !== true &&
           isPinned(this.attrs.trackState.id)) {
         movementY /=2;
       }
@@ -396,7 +396,7 @@ export class TrackContent implements m.ClassComponent<TrackContentAttrs> {
 interface TrackComponentAttrs {
   trackState: TrackState;
   track: Track;
-  pinnedGroup?: boolean;
+  pinnedCopy?: boolean;
 }
 class TrackComponent implements m.ClassComponent<TrackComponentAttrs> {
   view({attrs}: m.CVnode<TrackComponentAttrs>) {
@@ -415,7 +415,7 @@ class TrackComponent implements m.ClassComponent<TrackComponentAttrs> {
           m(TrackShell, {
             track: attrs.track,
             trackState: attrs.trackState,
-            pinnedGroup: attrs.pinnedGroup}),
+            pinnedCopy: attrs.pinnedCopy}),
           m(TrackContent, {track: attrs.track}),
         ]);
   }
@@ -458,7 +458,7 @@ export class TrackButton implements m.ClassComponent<TrackButtonAttrs> {
 interface TrackPanelAttrs {
   id: string;
   selectable: boolean;
-  pinnedGroup?: boolean;
+  pinnedCopy?: boolean;
 }
 
 export class TrackPanel extends Panel<TrackPanelAttrs> {
@@ -467,12 +467,12 @@ export class TrackPanel extends Panel<TrackPanelAttrs> {
   // has disappeared.
   private track: Track|undefined;
   private trackState: TrackState|undefined;
-  private pinnedGroup?: boolean;
+  private pinnedCopy?: boolean;
 
   constructor(vnode: m.CVnode<TrackPanelAttrs>) {
     super();
     const trackId = vnode.attrs.id;
-    this.pinnedGroup = vnode.attrs.pinnedGroup;
+    this.pinnedCopy = vnode.attrs.pinnedCopy;
     const trackState = globals.state.tracks[trackId];
     if (trackState === undefined) {
       return;
@@ -493,7 +493,7 @@ export class TrackPanel extends Panel<TrackPanelAttrs> {
     return m(TrackComponent, {
       trackState: this.trackState,
       track: this.track,
-      pinnedGroup: this.pinnedGroup});
+      pinnedCopy: this.pinnedCopy});
   }
 
   oncreate() {

--- a/ui/src/frontend/viewer_page.ts
+++ b/ui/src/frontend/viewer_page.ts
@@ -314,7 +314,11 @@ class TraceViewer implements m.ClassComponent<TraceViewerAttrs> {
                   m(NotesPanel, {key: 'notes'}),
                   m(TickmarkPanel, {key: 'searchTickmarks'}),
                   ...globals.state.pinnedTracks.map(
-                      (id) => m(TrackPanel, {key: id, id, selectable: true})),
+                      (id) => m(TrackPanel, {
+                        key: id,
+                        id,
+                        selectable: true,
+                        pinnedCopy: true})),
                 ],
                 kind: 'OVERVIEW',
               })),


### PR DESCRIPTION
#### What it does

Addresses this [Sokatoa Issue](https://github.com/android-graphics/sokatoa/issues/1285)

#### How to test

Pin a track.
Resize the track using the bottom border.
It shouldn't become very dislocated
Resize the track in the pinned group as it should have the same effect
