### PR TITLE
Have Long Track names overflow similiar to track group names

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -379,7 +379,7 @@ $bottom-tab-padding: 10px;
     cursor: grab;
     grid-template-areas: "title buttons";
     grid-template-columns: 1fr auto;
-    align-items: center;
+    align-items: baseline;
     width: var(--track-shell-width);
     background: var(--main-background-color);
     border-right: 1px solid var(--main-foreground-color);
@@ -416,6 +416,8 @@ $bottom-tab-padding: 10px;
     h1 {
       grid-area: title;
       @include track_shell_title();
+      position: relative;
+      top: -5px;
     }
 
     .track-buttons {
@@ -423,6 +425,8 @@ $bottom-tab-padding: 10px;
       display: flex;
       height: 100%;
       align-items: center;
+      position: relative;
+      top: -5px;
     }
 
     .track-button {

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -34,26 +34,6 @@ import {
 import {getActiveVsyncData, renderVsyncColumns} from './vsync_helper';
 import {SCROLLING_TRACK_GROUP, getContainingTrackIds} from '../common/state';
 
-function getTitleSize(title: string): string|undefined {
-  const length = title.length;
-  if (length > 55) {
-    return '9px';
-  }
-  if (length > 50) {
-    return '10px';
-  }
-  if (length > 45) {
-    return '11px';
-  }
-  if (length > 40) {
-    return '12px';
-  }
-  if (length > 35) {
-    return '13px';
-  }
-  return undefined;
-}
-
 function isPinned(id: string) {
   return globals.state.pinnedTracks.indexOf(id) !== -1;
 }
@@ -170,9 +150,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       getContainingTrackIds(globals.state, attrs.trackState.id)?.length ?? 0) +
       1;
     const trackTitle = attrs.trackState.title ?? attrs.trackState.name;
-    const titleStyling: Record<string, string|undefined> = {
-      fontSize: getTitleSize(trackTitle),
-    };
+    const titleStyling: Record<string, string|undefined> = {};
       titleStyling.marginLeft = `${depth/2}rem`;
 
     const dragClass = this.dragging ? `drag` : '';


### PR DESCRIPTION
#### What it does

When TrackNames are very long we no longer shrink the title to super small font size.  We also prioritize the first line of the text since the whole text can be seen in the tooltip or resized to see more.
