### PR TITLE
Don't resize outside timeline boundary

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -522,6 +522,10 @@ canvas.main-canvas {
   user-select: none;
 }
 
+.scrolling-panel-container > .panels > *:last-child {
+  margin-bottom: 500px;
+}
+
 .panel {
   position: relative; // Otherwise canvas covers panel dom.
 

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -109,8 +109,8 @@ export class TrackGroupPanel extends Panel<Attrs> {
       return;
     }
     if (e.currentTarget instanceof HTMLElement) {
-      const pageElement = e.currentTarget.closest('div.page');
-      if (pageElement && pageElement instanceof HTMLDivElement) {
+      const timelineElement = e.currentTarget.closest('div.pan-and-zoom-content');
+      if (timelineElement && timelineElement instanceof HTMLDivElement) {
         let trackHeight = this.summaryTrack.getHeight();
         let mouseY = e.clientY;
         const mouseMoveEvent = (evMove: MouseEvent): void => {
@@ -128,23 +128,23 @@ export class TrackGroupPanel extends Panel<Attrs> {
           }
         };
         const mouseReturnEvent = () : void => {
-          pageElement.addEventListener('mousemove', mouseMoveEvent);
-          pageElement.removeEventListener('mouseenter', mouseReturnEvent);
+          timelineElement.addEventListener('mousemove', mouseMoveEvent);
+          timelineElement.removeEventListener('mouseenter', mouseReturnEvent);
         };
         const mouseLeaveEvent = () : void => {
-          pageElement.removeEventListener('mousemove', mouseMoveEvent);
-          pageElement.addEventListener('mouseenter', mouseReturnEvent);
+          timelineElement.removeEventListener('mousemove', mouseMoveEvent);
+          timelineElement.addEventListener('mouseenter', mouseReturnEvent);
         };
         const mouseUpEvent = (): void => {
-          pageElement.removeEventListener('mousemove', mouseMoveEvent);
-          pageElement.removeEventListener('mouseup', mouseUpEvent);
-          pageElement.removeEventListener('mouseenter', mouseReturnEvent);
-          pageElement.removeEventListener('mouseleave', mouseLeaveEvent);
+          timelineElement.removeEventListener('mousemove', mouseMoveEvent);
+          document.removeEventListener('mouseup', mouseUpEvent);
+          timelineElement.removeEventListener('mouseenter', mouseReturnEvent);
+          timelineElement.removeEventListener('mouseleave', mouseLeaveEvent);
         };
-        pageElement.addEventListener('mousemove', mouseMoveEvent);
-        pageElement.addEventListener('mouseleave', mouseLeaveEvent);
-        pageElement.addEventListener('mouseup', mouseUpEvent);
-        pageElement.removeEventListener('mousedown', this.resize);
+        timelineElement.addEventListener('mousemove', mouseMoveEvent);
+        timelineElement.addEventListener('mouseleave', mouseLeaveEvent);
+        document.addEventListener('mouseup', mouseUpEvent);
+        timelineElement.removeEventListener('mousedown', this.resize);
       }
     }
   };
@@ -155,13 +155,13 @@ export class TrackGroupPanel extends Panel<Attrs> {
           e.pageY - e.currentTarget.getBoundingClientRect().top >=
           e.currentTarget.clientHeight - MOUSE_TARGETING_THRESHOLD_PX
           ) {
-          const pageElement: HTMLDivElement | null = e.currentTarget.closest('div.page');
-          pageElement?.addEventListener('mousedown', this.resize);
+          const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
+          timelineElement?.addEventListener('mousedown', this.resize);
           e.currentTarget.style.cursor = 'row-resize';
           return;
       } else if (e.currentTarget instanceof HTMLElement) {
-        const pageElement: HTMLDivElement | null = e.currentTarget.closest('div.page');
-        pageElement?.removeEventListener('mousedown', this.resize);
+        const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
+        timelineElement?.removeEventListener('mousedown', this.resize);
         e.currentTarget.style.cursor = 'unset';
       }
     }
@@ -170,8 +170,8 @@ export class TrackGroupPanel extends Panel<Attrs> {
     if (this.summaryTrack && this.summaryTrack.supportsResizing &&
         e.currentTarget instanceof HTMLElement) {
       e.currentTarget.style.cursor = 'unset';
-      const pageElement: HTMLDivElement | null = e.currentTarget.closest('div.page');
-      pageElement?.removeEventListener('mousedown', this.resize);
+      const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
+      timelineElement?.removeEventListener('mousedown', this.resize);
     }
   }
 

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -192,8 +192,8 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       return;
     }
     if (e.currentTarget instanceof HTMLElement) {
-      const pageElement = e.currentTarget.closest('div.page');
-      if (pageElement && pageElement instanceof HTMLDivElement) {
+      const timelineElement = e.currentTarget.closest('div.pan-and-zoom-content');
+      if (timelineElement && timelineElement instanceof HTMLDivElement) {
         let trackHeight = this.attrs.track.getHeight();
         let mouseY = e.clientY;
         const mouseMoveEvent = (evMove: MouseEvent): void => {
@@ -219,23 +219,23 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
           }
         };
         const mouseReturnEvent = () : void => {
-          pageElement.addEventListener('mousemove', mouseMoveEvent);
-          pageElement.removeEventListener('mouseenter', mouseReturnEvent);
+          timelineElement.addEventListener('mousemove', mouseMoveEvent);
+          timelineElement.removeEventListener('mouseenter', mouseReturnEvent);
         };
         const mouseLeaveEvent = () : void => {
-          pageElement.removeEventListener('mousemove', mouseMoveEvent);
-          pageElement.addEventListener('mouseenter', mouseReturnEvent);
+          timelineElement.removeEventListener('mousemove', mouseMoveEvent);
+          timelineElement.addEventListener('mouseenter', mouseReturnEvent);
         };
         const mouseUpEvent = (): void => {
-          pageElement.removeEventListener('mousemove', mouseMoveEvent);
-          pageElement.removeEventListener('mouseup', mouseUpEvent);
-          pageElement.removeEventListener('mouseenter', mouseReturnEvent);
-          pageElement.removeEventListener('mouseleave', mouseLeaveEvent);
+          timelineElement.removeEventListener('mousemove', mouseMoveEvent);
+          document.removeEventListener('mouseup', mouseUpEvent);
+          timelineElement.removeEventListener('mouseenter', mouseReturnEvent);
+          timelineElement.removeEventListener('mouseleave', mouseLeaveEvent);
         };
-        pageElement.addEventListener('mousemove', mouseMoveEvent);
-        pageElement.addEventListener('mouseleave', mouseLeaveEvent);
-        pageElement.addEventListener('mouseup', mouseUpEvent);
-        pageElement.removeEventListener('mousedown', this.resize);
+        timelineElement.addEventListener('mousemove', mouseMoveEvent);
+        timelineElement.addEventListener('mouseleave', mouseLeaveEvent);
+        document.addEventListener('mouseup', mouseUpEvent);
+        timelineElement.removeEventListener('mousedown', this.resize);
       }
     }
   };
@@ -245,13 +245,13 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       if (e.currentTarget instanceof HTMLElement &&
         e.pageY - e.currentTarget.getBoundingClientRect().top >=
           e.currentTarget.clientHeight - 5) {
-            const pageElement: HTMLDivElement | null = e.currentTarget.closest('div.page');
-            pageElement?.addEventListener('mousedown', this.resize);
+            const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
+            timelineElement?.addEventListener('mousedown', this.resize);
             e.currentTarget.style.cursor = 'row-resize';
             return;
       } else if (e.currentTarget instanceof HTMLElement) {
-        const pageElement: HTMLDivElement | null = e.currentTarget.closest('div.page');
-        pageElement?.removeEventListener('mousedown', this.resize);
+        const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
+        timelineElement?.removeEventListener('mousedown', this.resize);
         e.currentTarget.style.cursor = 'unset';
       }
     }
@@ -260,8 +260,8 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
     if (this.attrs?.track.supportsResizing &&
         e.currentTarget instanceof HTMLElement) {
       e.currentTarget.style.cursor = 'unset';
-      const pageElement: HTMLDivElement | null = e.currentTarget.closest('div.page');
-      pageElement?.removeEventListener('mousedown', this.resize);
+      const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
+      timelineElement?.removeEventListener('mousedown', this.resize);
     }
   }
 

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -108,11 +108,7 @@ export function resizeTrack(
         trackHeight += movementY;
         mouseY = evMove.clientY;
         const newMultiplier = trackHeight / defaultHeight;
-        if (newMultiplier < 1) {
-          trackState.scaleFactor = 1;
-        } else {
-          trackState.scaleFactor = newMultiplier;
-        }
+        trackState.scaleFactor = Math.min(1, newMultiplier);
         globals.rafScheduler.scheduleFullRedraw();
       };
       const mouseReturnEvent = () : void => {

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -65,6 +65,77 @@ function isSelected(id: string) {
   return selectedArea.tracks.includes(id);
 }
 
+const RESIZING_HEIGHT_PX = 5;
+export function checkTrackForResizability(
+  e: MouseEvent,
+  track: Track,
+  resize: (e: MouseEvent) => void): void {
+    if (track.supportsResizing) {
+      if (e.currentTarget instanceof HTMLElement &&
+          e.type !== 'mouseleave' &&
+          e.pageY - e.currentTarget.getBoundingClientRect().top >=
+          e.currentTarget.clientHeight - RESIZING_HEIGHT_PX
+          ) {
+          const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
+          timelineElement?.addEventListener('mousedown', resize);
+          e.currentTarget.style.cursor = 'row-resize';
+          return;
+      } else if (e.currentTarget instanceof HTMLElement) {
+        const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
+        timelineElement?.removeEventListener('mousedown', resize);
+        e.currentTarget.style.cursor = 'unset';
+      }
+    }
+}
+export function resizeTrack(
+  e: MouseEvent,
+  track: Track,
+  trackState: TrackState,
+  defaultHeight: number,
+  pinnedCopy?: boolean ): void {
+  if (e.currentTarget instanceof HTMLElement) {
+    const timelineElement = e.currentTarget.closest('div.pan-and-zoom-content');
+    if (timelineElement && timelineElement instanceof HTMLDivElement) {
+      let trackHeight = track.getHeight();
+      let mouseY = e.clientY;
+      const mouseMoveEvent = (evMove: MouseEvent): void => {
+        evMove.preventDefault();
+        let movementY = evMove.clientY-mouseY;
+        if (pinnedCopy !== true &&
+          isPinned(trackState.id)) {
+          movementY /=2;
+        }
+        trackHeight += movementY;
+        mouseY = evMove.clientY;
+        const newMultiplier = trackHeight / defaultHeight;
+        if (newMultiplier < 1) {
+          trackState.scaleFactor = 1;
+        } else {
+          trackState.scaleFactor = newMultiplier;
+        }
+        globals.rafScheduler.scheduleFullRedraw();
+      };
+      const mouseReturnEvent = () : void => {
+        timelineElement.addEventListener('mousemove', mouseMoveEvent);
+        timelineElement.removeEventListener('mouseenter', mouseReturnEvent);
+      };
+      const mouseLeaveEvent = () : void => {
+        timelineElement.removeEventListener('mousemove', mouseMoveEvent);
+        timelineElement.addEventListener('mouseenter', mouseReturnEvent);
+      };
+      const mouseUpEvent = (): void => {
+        timelineElement.removeEventListener('mousemove', mouseMoveEvent);
+        document.removeEventListener('mouseup', mouseUpEvent);
+        timelineElement.removeEventListener('mouseenter', mouseReturnEvent);
+        timelineElement.removeEventListener('mouseleave', mouseLeaveEvent);
+      };
+      timelineElement.addEventListener('mousemove', mouseMoveEvent);
+      timelineElement.addEventListener('mouseleave', mouseLeaveEvent);
+      document.addEventListener('mouseup', mouseUpEvent);
+    }
+  }
+};
+
 interface TrackShellAttrs {
   track: Track;
   trackState: TrackState;
@@ -185,83 +256,29 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
               }) :
               ''));
   }
+
   resize = (e: MouseEvent): void => {
     e.stopPropagation();
     e.preventDefault();
-    if (!this.attrs) {
+    if (!this.attrs || !this.defaultHeight) {
       return;
     }
-    if (e.currentTarget instanceof HTMLElement) {
-      const timelineElement = e.currentTarget.closest('div.pan-and-zoom-content');
-      if (timelineElement && timelineElement instanceof HTMLDivElement) {
-        let trackHeight = this.attrs.track.getHeight();
-        let mouseY = e.clientY;
-        const mouseMoveEvent = (evMove: MouseEvent): void => {
-          evMove.preventDefault();
-          if (!this.attrs) {
-            return;
-          }
-          let movementY = evMove.clientY-mouseY;
-          if (this.attrs.pinnedCopy !== true &&
-            isPinned(this.attrs.trackState.id)) {
-            movementY /=2;
-          }
-          trackHeight += movementY;
-          mouseY = evMove.clientY;
-          if (this.attrs && this.defaultHeight) {
-            const newMultiplier = trackHeight / this.defaultHeight;
-            if (newMultiplier < 1) {
-              this.attrs.trackState.scaleFactor = 1;
-            } else {
-              this.attrs.trackState.scaleFactor = newMultiplier;
-            }
-            globals.rafScheduler.scheduleFullRedraw();
-          }
-        };
-        const mouseReturnEvent = () : void => {
-          timelineElement.addEventListener('mousemove', mouseMoveEvent);
-          timelineElement.removeEventListener('mouseenter', mouseReturnEvent);
-        };
-        const mouseLeaveEvent = () : void => {
-          timelineElement.removeEventListener('mousemove', mouseMoveEvent);
-          timelineElement.addEventListener('mouseenter', mouseReturnEvent);
-        };
-        const mouseUpEvent = (): void => {
-          timelineElement.removeEventListener('mousemove', mouseMoveEvent);
-          document.removeEventListener('mouseup', mouseUpEvent);
-          timelineElement.removeEventListener('mouseenter', mouseReturnEvent);
-          timelineElement.removeEventListener('mouseleave', mouseLeaveEvent);
-        };
-        timelineElement.addEventListener('mousemove', mouseMoveEvent);
-        timelineElement.addEventListener('mouseleave', mouseLeaveEvent);
-        document.addEventListener('mouseup', mouseUpEvent);
-        timelineElement.removeEventListener('mousedown', this.resize);
-      }
-    }
+    resizeTrack(
+      e,
+      this.attrs.track,
+      this.attrs.trackState,
+      this.defaultHeight,
+      this.attrs.pinnedCopy);
   };
 
   onmousemove(e: MouseEvent) {
-    if (this.attrs?.track.supportsResizing) {
-      if (e.currentTarget instanceof HTMLElement &&
-        e.pageY - e.currentTarget.getBoundingClientRect().top >=
-          e.currentTarget.clientHeight - 5) {
-            const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
-            timelineElement?.addEventListener('mousedown', this.resize);
-            e.currentTarget.style.cursor = 'row-resize';
-            return;
-      } else if (e.currentTarget instanceof HTMLElement) {
-        const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
-        timelineElement?.removeEventListener('mousedown', this.resize);
-        e.currentTarget.style.cursor = 'unset';
-      }
+    if (this.attrs?.track) {
+      checkTrackForResizability(e, this.attrs.track, this.resize);
     }
   }
   onmouseleave(e: MouseEvent) {
-    if (this.attrs?.track.supportsResizing &&
-        e.currentTarget instanceof HTMLElement) {
-      e.currentTarget.style.cursor = 'unset';
-      const timelineElement: HTMLDivElement | null = e.currentTarget.closest('div.pan-and-zoom-content');
-      timelineElement?.removeEventListener('mousedown', this.resize);
+    if (this.attrs?.track) {
+      checkTrackForResizability(e, this.attrs.track, this.resize);
     }
   }
 


### PR DESCRIPTION
#### What it does

This PR is made in response to [this issue](https://github.com/android-graphics/sokatoa/issues/1286) regarding how track resizing handles the bottom track group.  It was brought up that the resizing continued even when the mouse left the scope of the timeline and/or application.  This PR stops resizing a track or track group if the mouse leaves the boundaries of the timeline