### PR TITLE
Swap Min for Max in Resize Logic so that tracks can increase in height

### DIFF
--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -108,7 +108,7 @@ export function resizeTrack(
         trackHeight += movementY;
         mouseY = evMove.clientY;
         const newMultiplier = trackHeight / defaultHeight;
-        trackState.scaleFactor = Math.min(1, newMultiplier);
+        trackState.scaleFactor = Math.max(1, newMultiplier);
         globals.rafScheduler.scheduleFullRedraw();
       };
       const mouseReturnEvent = () : void => {


### PR DESCRIPTION
#### What it does

I thought I tested this and it worked, but the tracks were only going below 1 scaleFactor, but after this change they will always be a Minimum of 1 scaleFactor rather than a maximum.
