### PR TITLE
[Design] CPU Slices Visual Update

### DIFF
--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -1336,6 +1336,11 @@ export const StateActions = {
     state.hoveredUtid = args.utid;
   },
 
+  setSelectedUtidAndPid(state: StateDraft, args: {utid: number, pid: number}) {
+    state.selectedPid = args.pid;
+    state.selectedUtid = args.utid;
+  },
+
   setHighlightedSliceId(state: StateDraft, args: {sliceId: number}) {
     state.highlightedSliceId = args.sliceId;
   },

--- a/ui/src/common/colorizer.ts
+++ b/ui/src/common/colorizer.ts
@@ -26,13 +26,13 @@ export interface Color {
 }
 
 const MD_PALETTE: Color[] = [
-  {c: 'teal', h: 173, s: 43, l: 56},
-  {c: 'purple', h: 267, s: 72, l: 73},
-  {c: 'peach', h: 23, s: 79, l: 72},
-  {c: 'red', h: 4, s: 70, l: 74},
-  {c: 'yellow', h: 46, s: 88, l: 76},
-  {c: 'green', h: 125, s: 40, l: 67},
-  {c: 'blue', h: 220, s: 91, l: 65},
+  {c: 'teal', h: 173, s: 43, l: 70},
+  {c: 'purple', h: 267, s: 72, l: 70},
+  {c: 'peach', h: 23, s: 79, l: 70},
+  {c: 'red', h: 4, s: 70, l: 70},
+  {c: 'yellow', h: 46, s: 88, l: 70},
+  {c: 'green', h: 125, s: 40, l: 70},
+  {c: 'blue', h: 220, s: 91, l: 70},
 ];
 
 export const GRAY_COLOR: Color = {

--- a/ui/src/common/colorizer.ts
+++ b/ui/src/common/colorizer.ts
@@ -26,24 +26,13 @@ export interface Color {
 }
 
 const MD_PALETTE: Color[] = [
-  {c: 'red', h: 4, s: 90, l: 58},
-  {c: 'pink', h: 340, s: 82, l: 52},
-  {c: 'purple', h: 291, s: 64, l: 42},
-  {c: 'deep purple', h: 262, s: 52, l: 47},
-  {c: 'indigo', h: 231, s: 48, l: 48},
-  {c: 'blue', h: 207, s: 90, l: 54},
-  {c: 'light blue', h: 199, s: 98, l: 48},
-  {c: 'cyan', h: 187, s: 100, l: 42},
-  {c: 'teal', h: 174, s: 100, l: 29},
-  {c: 'green', h: 122, s: 39, l: 49},
-  {c: 'light green', h: 88, s: 50, l: 53},
-  {c: 'lime', h: 66, s: 70, l: 54},
-  {c: 'amber', h: 45, s: 100, l: 51},
-  {c: 'orange', h: 36, s: 100, l: 50},
-  {c: 'deep orange', h: 14, s: 100, l: 57},
-  {c: 'brown', h: 16, s: 25, l: 38},
-  {c: 'blue gray', h: 200, s: 18, l: 46},
-  {c: 'yellow', h: 54, s: 100, l: 62},
+  {c: 'teal', h: 173, s: 43, l: 56},
+  {c: 'purple', h: 267, s: 72, l: 73},
+  {c: 'peach', h: 23, s: 79, l: 72},
+  {c: 'red', h: 4, s: 70, l: 74},
+  {c: 'yellow', h: 46, s: 88, l: 76},
+  {c: 'green', h: 125, s: 40, l: 67},
+  {c: 'blue', h: 220, s: 91, l: 65},
 ];
 
 export const GRAY_COLOR: Color = {

--- a/ui/src/common/empty_state.ts
+++ b/ui/src/common/empty_state.ts
@@ -142,6 +142,8 @@ export function createEmptyState(): State {
     sidebarVisible: true,
     hoveredUtid: -1,
     hoveredPid: -1,
+    selectedUtid: -1,
+    selectedPid: -1,
     hoverCursorTimestamp: -1n,
     hoveredNoteTimestamp: -1n,
     highlightedSliceId: -1,

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -595,6 +595,8 @@ export interface State {
   // Hovered and focused events
   hoveredUtid: number;
   hoveredPid: number;
+  selectedUtid: number;
+  selectedPid: number;
   hoverCursorTimestamp: TPTime;
   hoveredNoteTimestamp: TPTime;
   highlightedSliceId: number;

--- a/ui/src/tracks/cpu_slices/index.ts
+++ b/ui/src/tracks/cpu_slices/index.ts
@@ -309,15 +309,18 @@ class CpuSliceTrack extends Track<Config, Data> {
           data.ids[i] ===selection.id;
       };
 
+      ctx.strokeStyle = `hsl(${color.h}, ${color.s}%, ${color.l}%)`;
       ctx.fillStyle = `hsl(${GRAY_COLOR.h}, ${GRAY_COLOR.s}%, ${greyl}%)`;
       if (isSelected()) {
+        color.l = 60;
         ctx.fillStyle = `hsl(${color.h}, ${color.s}%, ${color.l}%)`;
       } else if (isHovering && (isProcessHovered || isThreadHovered) &&
         globals.state.currentSelection !== null &&
         globals.state.currentSelection.kind === 'SLICE'
       ) {
         // LikeCase
-        ctx.fillStyle = `hsl(${color.h}, ${color.s}%, 30%)`;
+        color.l = 30;
+        ctx.fillStyle = `hsl(${color.h}, ${color.s}%, ${color.l}%)`;
       }
 
       const right = Math.min(visWindowEndPx, rectEnd);
@@ -335,7 +338,6 @@ class CpuSliceTrack extends Track<Config, Data> {
       //  Extras
       if (isHovered()) {
         // Draw a rectangle around the slice that is currently selected.
-        ctx.strokeStyle = `hsl(${color.h}, ${color.s}%, ${color.l}%)`;
         ctx.beginPath();
         ctx.lineWidth = 3;
         ctx.strokeRect(left+1.5, MARGIN_TOP + 1.5, visibleWidth-3,

--- a/ui/src/tracks/cpu_slices/index.ts
+++ b/ui/src/tracks/cpu_slices/index.ts
@@ -217,6 +217,7 @@ class CpuSliceTrack extends Track<Config, Data> {
 
   private mousePos?: {x: number, y: number};
   private utidHoveredInThisTrack = -1;
+  private hoveredSlice: number | undefined;
 
   constructor(args: NewTrackArgs) {
     super(args);
@@ -300,8 +301,8 @@ class CpuSliceTrack extends Track<Config, Data> {
       const color = colorForThread(threadInfo);
       const greyIdx = hash(pid.toString(), 6)+1;
       const greyl = 55 - (5 * greyIdx);
-      const isHovered = (): boolean =>{
-        return isHovering && isThreadHovered && isProcessHovered;
+      const isHovered = (index: number): boolean =>{
+        return isHovering && index === this.hoveredSlice;
       };
       const isSelected = (): boolean=>{
         const selection = globals.state.currentSelection;
@@ -336,7 +337,7 @@ class CpuSliceTrack extends Track<Config, Data> {
       }
 
       //  Extras
-      if (isHovered()) {
+      if (isHovered(i)) {
         // Draw a rectangle around the slice that is currently selected.
         ctx.beginPath();
         ctx.lineWidth = 3;
@@ -474,13 +475,14 @@ class CpuSliceTrack extends Track<Config, Data> {
     }
     const t = visibleTimeScale.pxToHpTime(pos.x);
     let hoveredUtid = -1;
-
+    this.hoveredSlice=undefined;
     for (let i = 0; i < data.starts.length; i++) {
       const tStart = data.starts[i];
       const tEnd = data.ends[i];
       const utid = data.utids[i];
       if (t.gte(tStart) && t.lt(tEnd)) {
         hoveredUtid = utid;
+        this.hoveredSlice =i;
         break;
       }
     }
@@ -493,6 +495,7 @@ class CpuSliceTrack extends Track<Config, Data> {
 
   onMouseOut() {
     this.utidHoveredInThisTrack = -1;
+    this.hoveredSlice = undefined;
     globals.dispatch(Actions.setHoveredUtidAndPid({utid: -1, pid: -1}));
     this.mousePos = undefined;
   }

--- a/ui/src/tracks/cpu_slices/index.ts
+++ b/ui/src/tracks/cpu_slices/index.ts
@@ -317,8 +317,7 @@ class CpuSliceTrack extends Track<Config, Data> {
         globals.state.currentSelection.kind === 'SLICE'
       ) {
         // LikeCase
-        color.l = 30;
-        ctx.fillStyle = `hsl(${color.h}, ${color.s}%, ${color.l}%)`;
+        ctx.fillStyle = `hsl(${color.h}, ${color.s}%, 30%)`;
       }
 
       const right = Math.min(visWindowEndPx, rectEnd);


### PR DESCRIPTION
Implement new CPU Slice Styles from Argo Design

What this doesn't yet do:
- [x]  Bring down color palette to the 7 specified in the doc

Selection with LikeCase:

![image](https://github.com/eclipsesource/perfetto/assets/121060410/b7959700-bda8-45b7-b3ba-4427c52eb52b)

Hover No Selection:

![image](https://github.com/eclipsesource/perfetto/assets/121060410/2ab502ed-ceb9-4a95-a8f9-38e8654aaf9e)
