### PR TITLE
[Design] Show timeline behind expanded track groups

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -724,22 +724,12 @@ button.query-ctrl {
     opacity: 1;
   }
   &[collapsed="true"] {
-    .shell {
-      border-right: 1px solid var(--main-foreground-color);
-      background-color: var(--collapsed-background);
-      overflow: hidden;
-    }
     .track-button {
       color: rgb(60, 86, 136);
     }
   }
   &[collapsed="false"] {
-    background-color: var(--collapsed-background);
-    color: var(--main-foreground-color);
     font-weight: bold;
-    .shell {
-      overflow: hidden;
-    }
     span.chip {
       color: #121212;
     }
@@ -751,8 +741,12 @@ button.query-ctrl {
     grid-template-columns: 28px 1fr auto;
     align-items: baseline;
     line-height: 1;
+    border-right: 1px solid var(--main-foreground-color);
     width: var(--track-shell-width);
     transition: background-color 0.4s;
+    background-color: var(--collapsed-background);
+    color: var(--main-foreground-color);
+    overflow: hidden;
 
     .track-title {
       user-select: text;

--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -1251,23 +1251,48 @@ export const StateActions = {
     const areaId = selection.areaId;
     const index = state.areas[areaId].tracks.indexOf(args.id);
     if (index > -1) {
-      state.areas[areaId].tracks.splice(index, 1);
-      if (args.isTrackGroup) {  // Also remove all child tracks.
-        for (const childTrack of state.trackGroups[args.id].tracks) {
+      const removeTrackGroup = (id:string)=> {
+        const groupIndex = state.areas[areaId].tracks.indexOf(id);
+        // remove group
+        state.areas[areaId].tracks.splice(groupIndex, 1);
+        // Also remove all child tracks.
+        for (const childTrack of state.trackGroups[id].tracks) {
           const childIndex = state.areas[areaId].tracks.indexOf(childTrack);
           if (childIndex > -1) {
             state.areas[areaId].tracks.splice(childIndex, 1);
           }
         }
+        // Also remove all child track groups.
+        for (const childTrack of state.trackGroups[id].subgroups) {
+          removeTrackGroup(childTrack);
+        }
+      };
+      if (args.isTrackGroup) {
+        removeTrackGroup(args.id);
+      } else {
+        state.areas[areaId].tracks.splice(index, 1);
       }
     } else {
-      state.areas[areaId].tracks.push(args.id);
-      if (args.isTrackGroup) {  // Also add all child tracks.
-        for (const childTrack of state.trackGroups[args.id].tracks) {
+      const addTrackGroup = (id:string)=> {
+        // add group
+        state.areas[areaId].tracks.push(id);
+        // Also add all child tracks.
+        for (const childTrack of state.trackGroups[id].tracks) {
           if (!state.areas[areaId].tracks.includes(childTrack)) {
             state.areas[areaId].tracks.push(childTrack);
           }
         }
+        // Also add all child track groups.
+        for (const childTrack of state.trackGroups[id].subgroups) {
+          if (!state.areas[areaId].tracks.includes(childTrack)) {
+            addTrackGroup(childTrack);
+          }
+        }
+      };
+      if (args.isTrackGroup) {
+        addTrackGroup(args.id);
+      } else {
+        state.areas[areaId].tracks.push(args.id);
       }
     }
     // It's super unexpected that |toggleTrackSelection| does not cause

--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -165,15 +165,19 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
         continue;
       }
       if (panel.attrs.trackGroupId !== undefined) {
-        const trackGroup = globals.state.trackGroups[panel.attrs.trackGroupId];
-        // Only select a track group and all child tracks if it is closed.
-        tracks.push(panel.attrs.trackGroupId);
-        for (const track of trackGroup.tracks) {
-          tracks.push(track);
-        }
-        for (const group of trackGroup.subgroups) {
-          tracks.push(group);
-        }
+        const addTracks = (trackGroupId: string)=>{
+          const trackGroup =
+            globals.state.trackGroups[trackGroupId];
+          // Only select a track group and all child tracks if it is closed.
+          tracks.push(trackGroupId);
+          for (const track of trackGroup.tracks) {
+            tracks.push(track);
+          }
+          for (const group of trackGroup.subgroups) {
+            addTracks(group);
+          }
+        };
+        addTracks(panel.attrs.trackGroupId);
       }
     }
     globals.frontendLocalState.selectArea(area.start, area.end, tracks);

--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -167,11 +167,12 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
       if (panel.attrs.trackGroupId !== undefined) {
         const trackGroup = globals.state.trackGroups[panel.attrs.trackGroupId];
         // Only select a track group and all child tracks if it is closed.
-        if (trackGroup.collapsed) {
-          tracks.push(panel.attrs.trackGroupId);
-          for (const track of trackGroup.tracks) {
-            tracks.push(track);
-          }
+        tracks.push(panel.attrs.trackGroupId);
+        for (const track of trackGroup.tracks) {
+          tracks.push(track);
+        }
+        for (const group of trackGroup.subgroups) {
+          tracks.push(group);
         }
       }
     }

--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -158,10 +158,10 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
         startY,
         endY);
     // Get the track ids from the panels.
-    const tracks = [];
+    const tracks = new Set<string>();
     for (const panel of panels) {
       if (panel.attrs.id !== undefined) {
-        tracks.push(panel.attrs.id);
+        tracks.add(panel.attrs.id);
         continue;
       }
       if (panel.attrs.trackGroupId !== undefined) {
@@ -169,9 +169,9 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
           const trackGroup =
             globals.state.trackGroups[trackGroupId];
           // Only select a track group and all child tracks if it is closed.
-          tracks.push(trackGroupId);
+          tracks.add(trackGroupId);
           for (const track of trackGroup.tracks) {
-            tracks.push(track);
+            tracks.add(track);
           }
           for (const group of trackGroup.subgroups) {
             addTracks(group);
@@ -180,7 +180,8 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
         addTracks(panel.attrs.trackGroupId);
       }
     }
-    globals.frontendLocalState.selectArea(area.start, area.end, tracks);
+    globals.frontendLocalState.selectArea(
+      area.start, area.end, Array.from(tracks.values()));
   }
 
   constructor(vnode: m.CVnode<Attrs>) {

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -50,7 +50,6 @@ interface Attrs {
 export class TrackGroupPanel extends Panel<Attrs> {
   private readonly trackGroupId: string;
   private shellWidth = 0;
-  private backgroundColor = '#ffffff';  // Updated from CSS later.
   private summaryTrack: Track|undefined;
   private dragging = false;
   private dropping: 'before'|'after'|undefined = undefined;
@@ -334,9 +333,6 @@ export class TrackGroupPanel extends Panel<Attrs> {
     // const trackTitle = dom.querySelector('.track-title')!;
     // this.overFlown =  trackTitle.scrollHeight >= trackTitle.clientHeight;
     this.shellWidth = shell.getBoundingClientRect().width;
-    // TODO(andrewbb): move this to css_constants
-    this.backgroundColor =
-          getComputedStyle(dom).getPropertyValue('--collapsed-background');
     if (this.summaryTrack !== undefined) {
       this.summaryTrack.onFullRedraw();
     }
@@ -428,13 +424,6 @@ export class TrackGroupPanel extends Panel<Attrs> {
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D, size: PanelSize) {
-    const collapsed = this.trackGroupState.collapsed;
-
-    ctx.fillStyle = this.backgroundColor;
-    ctx.fillRect(0, 0, size.width, size.height);
-
-    if (!collapsed) return;
-
     // If we have vsync data, render columns under the track group
     const vsync = getActiveVsyncData();
     if (vsync) {

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -330,8 +330,6 @@ export class TrackGroupPanel extends Panel<Attrs> {
 
   onupdate({dom}: m.CVnodeDOM<Attrs>) {
     const shell = assertExists(dom.querySelector('.shell'));
-    // const trackTitle = dom.querySelector('.track-title')!;
-    // this.overFlown =  trackTitle.scrollHeight >= trackTitle.clientHeight;
     this.shellWidth = shell.getBoundingClientRect().width;
     if (this.summaryTrack !== undefined) {
       this.summaryTrack.onFullRedraw();
@@ -413,7 +411,8 @@ export class TrackGroupPanel extends Panel<Attrs> {
     if (!selection || selection.kind !== 'AREA') return;
     const selectedArea = globals.state.areas[selection.areaId];
     const selectedAreaDuration = selectedArea.end - selectedArea.start;
-    if (selectedArea.tracks.includes(this.trackGroupId)) {
+    if (selectedArea.tracks.includes(this.trackGroupId) ||
+      selectedArea.tracks.includes(this.summaryTrackState.id)) {
       ctx.fillStyle = getCssStr('--selection-fill-color');
       ctx.fillRect(
           visibleTimeScale.tpTimeToPx(selectedArea.start) + this.shellWidth,


### PR DESCRIPTION
#### What it does

Show summary tracks when track groups are expanded rather then dead space

Based on the Argo designs it seems that rather than highlighting expanded track groups in this way, we would just show an empty track content.  From my perspective we could instead display the track group's summary track.  
It would look something like this: 
![image](https://github.com/android-graphics/sokatoa/assets/121060410/73bf1152-1348-4d06-88f4-2ed0af8f0132)

![image](https://github.com/android-graphics/sokatoa/assets/121060410/30c52315-2e6c-4a72-a138-e192f11e9862)


Also markers like notes would show through like normal tracks
![image](https://github.com/android-graphics/sokatoa/assets/121060410/92664d5a-4020-493f-838e-4ef1e9a9b5c5)

This will fix this issue: https://github.com/android-graphics/sokatoa/issues/519
May also fix: https://github.com/android-graphics/sokatoa/issues/469