### PR TITLE
Support selective hiding of custom buttons

### DIFF
--- a/ui/src/frontend/button_registry.ts
+++ b/ui/src/frontend/button_registry.ts
@@ -1,20 +1,44 @@
-import { Registry } from '../common/registry';
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Registry} from '../common/registry';
 
 export interface CustomButtonArgs {
     title: string;
     icon: string;
     callback: () => {};
+    /**
+     * An optional function determining whether the button should be shown.
+     * If absent, the button will always be shown.
+     */
+    isVisible?: () => boolean;
 }
+
 export class CustomButton {
     title: string;
     icon: string;
     callback: () => {};
+    isVisible?: () => boolean;
     kind: string;
+
     constructor(args: CustomButtonArgs) {
         this.title = args.title;
         this.icon = args.icon;
         this.callback = args.callback;
+        this.isVisible = args.isVisible;
         this.kind = args.title;
     }
 }
+
 export const customButtonRegistry = Registry.kindRegistry<CustomButton>();

--- a/ui/src/frontend/notes_panel.ts
+++ b/ui/src/frontend/notes_panel.ts
@@ -120,25 +120,23 @@ export class NotesPanel extends Panel {
 
     private renderCustomButtons(): m.Vnode<any, any>[] {
       const mithrilButtons: m.Vnode<any, any>[] = [];
-      const values = customButtonRegistry.values();
-      let result = values.next();
-      while (!result.done) {
-        if (!result.value) {
-          break;
+      for (const customButton of customButtonRegistry.values()) {
+        if (customButton.isVisible && !customButton.isVisible()) {
+          // This button is not to be shown at this time
+          continue;
         }
-        const savedValue = result.value;
+
         const htmlButton = m(
           'button',
           {
               onclick: (e: Event) => {
                   e.preventDefault();
-                  savedValue.callback();
+                  customButton.callback();
               },
           },
-          m('i.material-icons', {title: result.value.title}, result.value.icon),
+          m('i.material-icons', {title: customButton.title}, customButton.icon),
         );
         mithrilButtons.push(htmlButton);
-        result =values.next();
       }
       return mithrilButtons;
     }


### PR DESCRIPTION
This is a part of the fix for android-graphics/sokatoa#1746 in which it is necessary to be able to suppress some of the custom buttons in the Perfetto view when it is one of two inputs in a Comparison. In particular, in comparisons we don't show the custom button for creation of Combined Tracks.

So the API description of a custom button now includes an optional visibility function that the renderer of the Notes Panel uses to know whether it should instantiate the button or not.