### PR TITLE
Support to unregister from engine observer

### DIFF
--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -741,8 +741,18 @@ class Globals {
     }
   }
 
-  addEngineReadyObserver(observer: (engine: EngineConfig) => void): void {
-      this._engineReadyObservers.push(observer);
+  /** Register an engine ready observer.
+   *
+   * returns a cleanup function, to be called to unregister.
+   */
+  addEngineReadyObserver(observer: (engine: EngineConfig) => void): ()=>void {
+    this._engineReadyObservers.push(observer);
+    return ()=> {
+      const index = this._engineReadyObservers.indexOf(observer);
+      if (index >= 0) {
+        this._engineReadyObservers.splice(index, 1);
+      }
+    };
   }
 
   /**


### PR DESCRIPTION
We keep a set of perfetto instances and reuse them, hence each use needs to cleanup its references, or it is a memory leak.