### PR TITLE
Support removal of selection observers

### DIFF
--- a/ui/src/common/selection_observer.ts
+++ b/ui/src/common/selection_observer.ts
@@ -26,7 +26,18 @@ export function onSelectionChanged(
   }
 }
 
+// Add a selection-changed observer.
+// Returns a function that removes the observer.
 export function addSelectionChangeObserver(observer: SelectionChangedObserver):
-    void {
+    () => void {
   selectionObservers.push(observer);
+  return () => removeSelectionChangeObserver(observer);
+}
+
+function removeSelectionChangeObserver(observer: SelectionChangedObserver):
+    void {
+  const index = selectionObservers.indexOf(observer);
+  if (index >= 0) {
+    selectionObservers.splice(index, 1);
+  }
 }


### PR DESCRIPTION
Because Perfetto instances can be reused in Sokatoa, we need to be able to remove selection observers that were added from the containing application context. Otherwise, we'll have memory leaks when Sokatoa widgets (that at least in the Comparison widget) add selection observers and subsequently are themselves disposed, if they cannot then remove those observers.
