### PR TITLE
Perfetto help is too big causing issues

### DIFF
--- a/ui/src/assets/modal.scss
+++ b/ui/src/assets/modal.scss
@@ -49,6 +49,8 @@
   backdrop-filter: blur(2px);
   animation: modalFadeIn 0.25s var(--anim-easing);
   animation-fill-mode: both;
+  width: 100%;
+  height: 100%;
 
   &.modal-fadeout {
     animation: modalFadeOut 0.25s var(--anim-easing);
@@ -62,11 +64,11 @@
   background-color: var(--main-background-color);
   color: var(--main-foreground-color);
   margin: auto;
-  min-width: 25vw;
-  min-height: 10vh;
+  min-width: 25%;
+  min-height: 10%;
   padding: 30px;
-  max-width: 90vw;
-  max-height: 90vh;
+  max-width: 90%;
+  max-height: 90%;
   border-radius: $pf-border-radius;
   overflow-y: auto;
   top: 50%;


### PR DESCRIPTION
There were a number of issues with the Perfetto help UI because it was not fitting in the UI properly.  This was because it was using sizes based on the viewport which caused them to overflow their parent and be way larger than they need to be. 
![image](https://github.com/user-attachments/assets/dcdfb29c-02f4-4dec-a68f-148c198ac15a)