### PR TITLE
Hide Expanded Track Group Summary Track

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -728,6 +728,7 @@ button.query-ctrl {
     }
   }
   &[collapsed="false"] {
+    background-color: var(--collapsed-background);
     font-weight: bold;
     span.chip {
       color: #121212;


### PR DESCRIPTION
Undoes most of the work from https://github.com/eclipsesource/perfetto/pull/122
https://github.com/android-graphics/sokatoa/issues/2240 was added to document future work on this feature.
Hides the Summary Tracks since when track groups are expanded the track content may not match with the label when the label is stuck to the top of the UI.

Seeing as fixing this issue could take a large amount of changes to the Perfetto UI, I found it best to hide it as Perfetto did in the mean time.

Problem in question:
As you can see in this example the orange data from the duolingo track group is scrolling up into the Process track group which has no data.
![image](https://github.com/user-attachments/assets/fc220b0c-fe2a-4040-9c38-4a6284c09519)
![image_1](https://github.com/user-attachments/assets/2707d378-f2be-4703-9a4e-1a0c7055ba69)

Solution image:
![image](https://github.com/user-attachments/assets/85c52a24-dc30-4f7e-9ebd-ec247982475d)
