### PR TITLE
Short-circuit initialization of filtered-out tracks

### DIFF
--- a/ui/src/controller/track_controller.ts
+++ b/ui/src/controller/track_controller.ts
@@ -245,6 +245,12 @@ export abstract class TrackController<
         promise
             .then(() => {
               this.isSetup = true;
+
+              // The host application may have filtered this track out
+              if (!globals.state.tracks[this.trackId]) {
+                return;
+              }
+
               let resolution = visibleState.resolution;
 
               if (BigintMath.popcount(resolution) !== 1) {
@@ -257,7 +263,9 @@ export abstract class TrackController<
                   resolution);
             })
             .then((data) => {
-              this.publish(data);
+              if (data) {
+                this.publish(data);
+              }
             })
             .finally(() => {
               this.requestingData = false;


### PR DESCRIPTION
Double-check in handling the initialization promise that a track is not filtered out before computing the initial data from onBoundsChanged().

This is a fix for android-graphics/sokatoa#1692.