### PR TITLE
Always open the details of a new selection

### DIFF
--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -294,10 +294,12 @@ class Globals {
   private _trackFilteringEnabled = false;
   private _engineReadyObservers: ((engine: EngineConfig) => void)[] = [];
   private _timelineSubsetRange?: TimespanProvider = undefined;
+  private _alwaysOpenDetailsOnSelectionChange = true;
 
 
   // Init from session storage since correct value may be required very early on
-  private _customContentSecurityPolicy = window.sessionStorage.getItem(CUSTOM_CONTENT_SECURITY_POLICY);
+  private _customContentSecurityPolicy =
+    window.sessionStorage.getItem(CUSTOM_CONTENT_SECURITY_POLICY);
 
   private _currentSearchResults: CurrentSearchResults = {
     sliceIds: new Float64Array(0),
@@ -699,7 +701,8 @@ class Globals {
     return this._httpRpcEngineCustomizer;
   }
 
-  set httpRpcEngineCustomizer(httpRpcEngineCustomizer: HttpRcpEngineCustomizer | undefined) {
+  set httpRpcEngineCustomizer(
+      httpRpcEngineCustomizer: HttpRcpEngineCustomizer | undefined) {
     this._httpRpcEngineCustomizer = httpRpcEngineCustomizer;
   }
 
@@ -715,8 +718,10 @@ class Globals {
     return this._promptToLoadFromTraceProcessorShell;
   }
 
-  set promptToLoadFromTraceProcessorShell(promptToLoadFromTraceProcessorShell: boolean) {
-    this._promptToLoadFromTraceProcessorShell = promptToLoadFromTraceProcessorShell;
+  set promptToLoadFromTraceProcessorShell(
+      promptToLoadFromTraceProcessorShell: boolean) {
+    this._promptToLoadFromTraceProcessorShell =
+      promptToLoadFromTraceProcessorShell;
   }
 
   get trackFilteringEnabled(): boolean {
@@ -741,9 +746,11 @@ class Globals {
     }
   }
 
-  /** Register an engine ready observer.
+  /**
+   * Register an engine ready observer.
    *
-   * returns a cleanup function, to be called to unregister.
+   * @param {Function} observer an engine-ready call-back function to register
+   * @return {Function} a cleanup function, to be called to unregister
    */
   addEngineReadyObserver(observer: (engine: EngineConfig) => void): ()=>void {
     this._engineReadyObservers.push(observer);
@@ -771,6 +778,19 @@ class Globals {
    */
   set timelineSubsetRange(timeSpan: TimespanProvider | undefined) {
     this._timelineSubsetRange = timeSpan;
+  }
+
+  /**
+   * Whether the details pane is always opened to show the new selection
+   * on selection change (if the selection is not cleared), even when the
+   * user had previously closed it. Initially this is `true`.
+   */
+  get alwaysOpenDetailsOnSelectionChange() {
+    return this._alwaysOpenDetailsOnSelectionChange;
+  };
+
+  set alwaysOpenDetailsOnSelectionChange(always: boolean) {
+    this._alwaysOpenDetailsOnSelectionChange = always;
   }
 
   makeSelection(action: DeferredAction<{}>, tabToOpen = 'current_selection') {


### PR DESCRIPTION
Ensure that whenever the selection changes and the new selection exists, show it in the details panel even if the user had previously closed it.

Add a global flag to allow the host application to disable this behaviour, for example on a user preference setting.

Includes incidental fixing of lint problems in edited files.

This is a fix for android-graphics/sokatoa#2087.

----

To test, verify that you can:

1. Select a counter, slice, etc. in the Perfetto UI. On the first selection, the Details panel should appear to show it as before.
2. Close the Details panel using the chevron button.
3. Click the same object that was selected at step 1. The Details panel should not open because the selection is not changed.
4. Select some other object in the Perfetto UI. The Details panel should open to show it.
5. Select yet another object. The Details panel should show the new selection as before.
6. Clear the selection by clicking in the header strip of some closed track group. The details panel should close.
