### PR TITLE
Fix SQL errors in initialization of tracks that are already filtered out

### DIFF
--- a/ui/src/controller/track_controller.ts
+++ b/ui/src/controller/track_controller.ts
@@ -35,8 +35,6 @@ interface TrackConfig {}
 
 type TrackConfigWithNamespace = TrackConfig&{namespace: string};
 
-const cancelToken = Symbol('cancelled');
-
 // Helper type that asserts that two vararg parameters have the same length
 type SameLength<T extends unknown[], U extends unknown[]> =
 T extends { length: U['length'] } ? T : never;
@@ -360,7 +358,7 @@ export abstract class TrackController<
                   resolution);
             })
             .then((data) => {
-              if (this.isData(data)) {
+              if (data) {
                 this.publish(data);
               }
             })
@@ -373,20 +371,6 @@ export abstract class TrackController<
             });
       }
     }
-  }
-
-  /**
-   * Provide a non-viable Data serving as a token of cancellation of
-   * the bounds-change calculation.
-   *
-   * @return {Data} a token track-data object signalling cancellation
-   */
-  protected cancelData(): Data {
-    return {[cancelToken]: cancelToken} as unknown as Data;
-  }
-
-  private isData(data: Data | undefined): data is Data {
-    return !!data && !(cancelToken in data);
   }
 }
 

--- a/ui/src/controller/track_controller.ts
+++ b/ui/src/controller/track_controller.ts
@@ -15,6 +15,7 @@
 import {BigintMath} from '../base/bigint_math';
 import {assertExists} from '../base/logging';
 import {Engine} from '../common/engine';
+import {QueryResult} from '../common/query_result';
 import {Registry} from '../common/registry';
 import {TraceTime, TrackState} from '../common/state';
 import {
@@ -33,6 +34,12 @@ import {ControllerFactory} from './controller';
 interface TrackConfig {}
 
 type TrackConfigWithNamespace = TrackConfig&{namespace: string};
+
+const cancelToken = Symbol('cancelled');
+
+// Helper type that asserts that two vararg parameters have the same length
+type SameLength<T extends unknown[], U extends unknown[]> =
+T extends { length: U['length'] } ? T : never;
 
 // TrackController is a base class overridden by track implementations (e.g.,
 // sched slices, nestable slices, counters).
@@ -103,6 +110,96 @@ export abstract class TrackController<
     // Track ID can be UUID but '-' is not valid for sql table name.
     const idSuffix = this.trackId.split('-').join('_');
     return `${prefix}_${idSuffix}`;
+  }
+
+  /**
+   * Create a dynamic table with an automatically assigned name with
+   * convenient clean-up and handling of attempts to query the table
+   * after it has been dropped.
+   *
+   * @param {string} key to distinguish this table from other tables
+   *        and views dynamically created by the track
+   * @param {string|Function} ddl a function that generates the
+   *        table DDL using the dynamically assigned name of the
+   *        table and its dependencies from which it extracts data.
+   *        The DDL factory must accept a parameter for each dependency,
+   *        in order, to get its name
+   * @param {DynamicTable[]} withDependencies optional dynamic tables
+   *        from which the new table extracts data, thus being dependencies
+   * @return {DynamicTable} the dynamic table manager
+   */
+  protected createDynamicTable
+      <DN extends string[], DT extends DynamicTable[]>(
+      key: string,
+      ddl: (name: string, ...dependencies: DN) => string,
+      ...withDependencies: SameLength<DT, DN>): DynamicTable {
+    return this.createDynamicTableOrView('table', key, ddl, ...withDependencies);
+  }
+  /**
+   * Create a dynamic view with an automatically assigned name with
+   * convenient clean-up and handling of attempts to query the view
+   * after it has been dropped.
+   *
+   * @param {string} key to distinguish this view from other tables
+   *        and views dynamically created by the track
+   * @param {string|Function} ddl a function that generates the
+   *        view DDL using the dynamically assigned name of the
+   *        view and its dependencies from which it extracts data.
+   *        The DDL factory must accept a parameter for each dependency,
+   *        in order, to get its name
+   * @param {DynamicTable[]} withDependencies optional dynamic tables
+   *        from which the new view extracts data, thus being dependencies
+   * @return {DynamicTable} the dynamic view manager
+   */
+  protected createDynamicView
+      <DN extends string[], DT extends DynamicTable[]>(
+      key: string,
+      ddl: (name: string, ...dependencies: DN) => string,
+      ...withDependencies: SameLength<DT, DN>): DynamicTable {
+    return this.createDynamicTableOrView('view', key, ddl, ...withDependencies);
+  }
+  private createDynamicTableOrView
+      <DN extends string[], DT extends DynamicTable[]>(
+      type: DynamicTable['type'],
+      key: string,
+      ddl: (name: string, ...dependencies: DN) => string,
+      ...withDependencies: SameLength<DT, DN>): DynamicTable {
+    const name = this.tableName(key);
+    if (withDependencies.some((dep) => !dep.exists)) {
+      return DynamicTable.NONE;
+    }
+
+    const dependencyNames = withDependencies.map((dep) => dep.name) as DN;
+
+    let tableExists = true;
+    const pendingCreation = this.query(ddl(name, ...dependencyNames));
+    return {
+      type,
+      name,
+      get exists() {
+        return tableExists;
+      },
+      drop: async () => {
+        tableExists = false;
+        await pendingCreation;
+        await this.query(`drop ${type} if exists ${name}`);
+      },
+      query: async <T, E = undefined>(
+            query: string | ((tableName: string) => string),
+            resultCase?: (result: QueryResult) => T,
+            elseCase?: () => E) => {
+          if (!tableExists) {
+            return resultCase ? false : elseCase?.call(this);
+          }
+          const sql = typeof query === 'function' ? query(name) : query;
+          await pendingCreation;
+          const result = await this.query(sql);
+          if (!resultCase) {
+            return true;
+          }
+          return resultCase.call(this, result);
+      },
+    };
   }
 
   shouldSummarize(resolution: number): boolean {
@@ -263,7 +360,7 @@ export abstract class TrackController<
                   resolution);
             })
             .then((data) => {
-              if (data) {
+              if (this.isData(data)) {
                 this.publish(data);
               }
             })
@@ -277,6 +374,91 @@ export abstract class TrackController<
       }
     }
   }
+
+  /**
+   * Provide a non-viable Data serving as a token of cancellation of
+   * the bounds-change calculation.
+   *
+   * @return {Data} a token track-data object signalling cancellation
+   */
+  protected cancelData(): Data {
+    return {[cancelToken]: cancelToken} as unknown as Data;
+  }
+
+  private isData(data: Data | undefined): data is Data {
+    return !!data && !(cancelToken in data);
+  }
+}
+
+/**
+ * A wrapper for access to a dynamic-defined table or view
+ * that may or may not exist at any given time.
+ */
+export interface DynamicTable {
+  /** What kind of dynamic object that is encapsulated. */
+  readonly type: 'table'|'view';
+  /** The name of the dynamic object that is encapsulated. */
+  readonly name: string;
+  /** Whether the dynamic object that is encapsulated currently exists. */
+  readonly exists: boolean;
+  /**
+   * Drop the dynamically-defined table or view.
+   * From this point on, the query APIs will shunt to the else case.
+   */
+  drop(): Promise<void>;
+  /**
+   * Perform an UPDATE, DELETE, or other statement that does not return
+   * results, if and only if the dynamic table exists.
+   */
+  query(
+    query: string | ((tableName: string) => string)): Promise<boolean>;
+  /**
+   * Perform a SELECT query, if and only if the dynamic table exists, in
+   * which case the query result is sent to the given call-back function
+   * to process. There is no else-case call-back.
+   *
+   * @param query a query string or factory, which latter accepts the
+   *        dynamically-assigned table or view name as a parameter
+   * @param resultCase a call-back function to process the query result
+   */
+  query<T>(
+    query: string | ((tableName: string) => string),
+    resultCase: (result: QueryResult) => T): Promise<T | undefined>;
+  /**
+   * Perform a SELECT query, if and only if the dynamic table exists, in
+   * which case the query result is sent to the given call-back function
+   * to process. If the table does not exist, return the result of the
+   * else-case call-back function, instead.
+   *
+   * @param query a query string or factory, which latter accepts the
+   *        dynamically-assigned table or view name as a parameter
+   * @param resultCase a call-back function to process the query result
+   * @param elseCase a call-back function to call in the eventuality
+            that the table has already been dropped
+   */
+  query<T, E>(
+    query: string | ((tableName: string) => string),
+    resultCase: (result: QueryResult) => T,
+    elseCase: () => E): Promise<T | E>;
+}
+
+export namespace DynamicTable {
+  /** Placeholder for a dynamic table that has never (yet) been created. */
+  export const NONE: DynamicTable = {
+      type: 'view',
+      name: '<none>',
+      exists: false,
+      drop: () => Promise.resolve(),
+      query: async <T, E = undefined>(
+        _query: string | ((tableName: string) => string),
+        resultCase?: (result: QueryResult) => T,
+        elseCase?: () => E) => {
+          if (resultCase === undefined) {
+            return false;
+          }
+          return elseCase?.();
+        },
+  };
 }
 
 export interface TrackControllerArgs {

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -29,7 +29,7 @@ import {
 } from '../../common/plugin_api';
 import {TPDuration, TPTime, tpTimeToSeconds} from '../../common/time';
 import {TrackData} from '../../common/track_data';
-import {TrackController} from '../../controller/track_controller';
+import {DynamicTable, TrackController} from '../../controller/track_controller';
 import {checkerboardExcept} from '../../frontend/checkerboard';
 import {globals} from '../../frontend/globals';
 import {NewTrackArgs, Track} from '../../frontend/track';
@@ -77,13 +77,15 @@ class CounterTrackController extends TrackController<Config, Data> {
   private maximumDeltaSeen = 0;
   private minimumDeltaSeen = 0;
   private maxDurNs: TPDuration = 0n;
+  private counterView = DynamicTable.NONE;
 
   async onBoundsChange(start: TPTime, end: TPTime, resolution: TPDuration):
       Promise<Data> {
     if (!this.setup) {
+      let ddl: (counterView: string) => string;
       if (this.config.namespace === undefined) {
-        await this.query(`
-          create view ${this.tableName('counter_view')} as
+        ddl = (counterView) => `
+          create view ${counterView} as
           select
             id,
             ts,
@@ -92,10 +94,10 @@ class CounterTrackController extends TrackController<Config, Data> {
             delta
           from experimental_counter_dur
           where track_id = ${this.config.trackId};
-        `);
+        `;
       } else {
-        await this.query(`
-          create view ${this.tableName('counter_view')} as
+        ddl = (counterView) => `
+          create view ${counterView} as
           select
             id,
             ts,
@@ -104,102 +106,120 @@ class CounterTrackController extends TrackController<Config, Data> {
             value
           from ${this.namespaceTable('counter')}
           where track_id = ${this.config.trackId};
-        `);
+        `;
       }
+      this.counterView = this.createDynamicView('counter_view', ddl);
 
-      const maxDurResult = await this.query(`
+      await this.counterView.query((counterView) => `
           select
             max(
               iif(dur != -1, dur, (select end_ts from trace_bounds) - ts)
             ) as maxDur
-          from ${this.tableName('counter_view')}
-      `);
-      this.maxDurNs = maxDurResult.firstRow({maxDur: LONG_NULL}).maxDur || 0n;
+          from ${counterView}
+      `, (maxDurResult) => {
+          this.maxDurNs = maxDurResult.firstRow({
+            maxDur: LONG_NULL,
+          }).maxDur || 0n;
+        });
 
-      const queryRes = await this.query(`
+      await this.counterView.query((counterView) => `
         select
           ifnull(max(value), 0) as maxValue,
           ifnull(min(value), 0) as minValue,
           ifnull(max(delta), 0) as maxDelta,
           ifnull(min(delta), 0) as minDelta
-        from ${this.tableName('counter_view')}`);
-      const row = queryRes.firstRow(
-          {maxValue: NUM, minValue: NUM, maxDelta: NUM, minDelta: NUM});
-      this.maximumValueSeen = row.maxValue;
-      this.minimumValueSeen = row.minValue;
-      this.maximumDeltaSeen = row.maxDelta;
-      this.minimumDeltaSeen = row.minDelta;
+        from ${counterView}`,
+        (queryRes) => {
+          const row = queryRes.firstRow(
+              {maxValue: NUM, minValue: NUM, maxDelta: NUM, minDelta: NUM});
+          this.maximumValueSeen = row.maxValue;
+          this.minimumValueSeen = row.minValue;
+          this.maximumDeltaSeen = row.maxDelta;
+          this.minimumDeltaSeen = row.minDelta;
+        },
+      );
 
       this.setup = true;
     }
 
-    const queryRes = await this.query(`
-      select
-        (ts + ${resolution / 2n}) / ${resolution} * ${resolution} as tsq,
-        min(value) as minValue,
-        max(value) as maxValue,
-        sum(delta) as totalDelta,
-        value_at_max_ts(ts, id) as lastId,
-        value_at_max_ts(ts, value) as lastValue
-      from ${this.tableName('counter_view')}
-      where ts >= ${start - this.maxDurNs} and ts <= ${end}
-      group by tsq
-      order by tsq
-    `);
+    const result = await this.counterView.query((counterView) => `
+        select
+          (ts + ${resolution / 2n}) / ${resolution} * ${resolution} as tsq,
+          min(value) as minValue,
+          max(value) as maxValue,
+          sum(delta) as totalDelta,
+          value_at_max_ts(ts, id) as lastId,
+          value_at_max_ts(ts, value) as lastValue
+        from ${counterView}
+        where ts >= ${start - this.maxDurNs} and ts <= ${end}
+        group by tsq
+        order by tsq
+      `,
+      (queryRes) => {
+        const numRows = queryRes.numRows();
 
-    const numRows = queryRes.numRows();
+        const data: Data = {
+          start,
+          end,
+          length: numRows,
+          maximumValue: this.maximumValue(),
+          minimumValue: this.minimumValue(),
+          maximumDelta: this.maximumDeltaSeen,
+          minimumDelta: this.minimumDeltaSeen,
+          maximumRate: 0,
+          minimumRate: 0,
+          resolution,
+          timestamps: new BigInt64Array(numRows),
+          lastIds: new Float64Array(numRows),
+          minValues: new Float64Array(numRows),
+          maxValues: new Float64Array(numRows),
+          lastValues: new Float64Array(numRows),
+          totalDeltas: new Float64Array(numRows),
+          rate: new Float64Array(numRows),
+        };
 
-    const data: Data = {
-      start,
-      end,
-      length: numRows,
-      maximumValue: this.maximumValue(),
-      minimumValue: this.minimumValue(),
-      maximumDelta: this.maximumDeltaSeen,
-      minimumDelta: this.minimumDeltaSeen,
-      maximumRate: 0,
-      minimumRate: 0,
-      resolution,
-      timestamps: new BigInt64Array(numRows),
-      lastIds: new Float64Array(numRows),
-      minValues: new Float64Array(numRows),
-      maxValues: new Float64Array(numRows),
-      lastValues: new Float64Array(numRows),
-      totalDeltas: new Float64Array(numRows),
-      rate: new Float64Array(numRows),
-    };
+        const it = queryRes.iter({
+          'tsq': LONG,
+          'lastId': NUM,
+          'minValue': NUM,
+          'maxValue': NUM,
+          'lastValue': NUM,
+          'totalDelta': NUM,
+        });
+        let lastValue = 0;
+        let lastTs = 0n;
+        for (let row = 0; it.valid(); it.next(), row++) {
+          const ts = it.tsq;
+          const value = it.lastValue;
+          const rate = (value - lastValue) / (tpTimeToSeconds(ts - lastTs));
+          lastTs = ts;
+          lastValue = value;
 
-    const it = queryRes.iter({
-      'tsq': LONG,
-      'lastId': NUM,
-      'minValue': NUM,
-      'maxValue': NUM,
-      'lastValue': NUM,
-      'totalDelta': NUM,
-    });
-    let lastValue = 0;
-    let lastTs = 0n;
-    for (let row = 0; it.valid(); it.next(), row++) {
-      const ts = it.tsq;
-      const value = it.lastValue;
-      const rate = (value - lastValue) / (tpTimeToSeconds(ts - lastTs));
-      lastTs = ts;
-      lastValue = value;
+          data.timestamps[row] = ts;
+          data.lastIds[row] = it.lastId;
+          data.minValues[row] = it.minValue;
+          data.maxValues[row] = it.maxValue;
+          data.lastValues[row] = value;
+          data.totalDeltas[row] = it.totalDelta;
+          data.rate[row] = rate;
+          if (row > 0) {
+            data.rate[row - 1] = rate;
+            data.maximumRate = Math.max(data.maximumRate, rate);
+            data.minimumRate = Math.min(data.minimumRate, rate);
+          }
+        }
 
-      data.timestamps[row] = ts;
-      data.lastIds[row] = it.lastId;
-      data.minValues[row] = it.minValue;
-      data.maxValues[row] = it.maxValue;
-      data.lastValues[row] = value;
-      data.totalDeltas[row] = it.totalDelta;
-      data.rate[row] = rate;
-      if (row > 0) {
-        data.rate[row - 1] = rate;
-        data.maximumRate = Math.max(data.maximumRate, rate);
-        data.minimumRate = Math.min(data.minimumRate, rate);
-      }
-    }
-    return data;
+        return data;
+      },
+      () => this.cancelData(),
+    );
+
+    return result;
+  }
+
+  onDestroy(): void {
+    this.counterView.drop();
+    this.setup = false;
   }
 
   private maximumValue() {

--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -142,6 +142,31 @@ class CounterTrackController extends TrackController<Config, Data> {
       this.setup = true;
     }
 
+    const emptyBigInts = BigInt64Array.of();
+    const emptyFloats = Float64Array.of();
+
+    // Default to an empty data in case the query fails,
+    // e.g. on the track being filtered out
+    const data: Data = {
+      start,
+      end,
+      length: 0,
+      maximumValue: this.maximumValue(),
+      minimumValue: this.minimumValue(),
+      maximumDelta: this.maximumDeltaSeen,
+      minimumDelta: this.minimumDeltaSeen,
+      maximumRate: 0,
+      minimumRate: 0,
+      resolution,
+      timestamps: emptyBigInts,
+      lastIds: emptyFloats,
+      minValues: emptyFloats,
+      maxValues: emptyFloats,
+      lastValues: emptyFloats,
+      totalDeltas: emptyFloats,
+      rate: emptyFloats,
+    };
+
     const result = await this.counterView.query((counterView) => `
         select
           (ts + ${resolution / 2n}) / ${resolution} * ${resolution} as tsq,
@@ -158,17 +183,9 @@ class CounterTrackController extends TrackController<Config, Data> {
       (queryRes) => {
         const numRows = queryRes.numRows();
 
-        const data: Data = {
-          start,
-          end,
+        // Fill in the data from the query results
+        Object.assign(data, {
           length: numRows,
-          maximumValue: this.maximumValue(),
-          minimumValue: this.minimumValue(),
-          maximumDelta: this.maximumDeltaSeen,
-          minimumDelta: this.minimumDeltaSeen,
-          maximumRate: 0,
-          minimumRate: 0,
-          resolution,
           timestamps: new BigInt64Array(numRows),
           lastIds: new Float64Array(numRows),
           minValues: new Float64Array(numRows),
@@ -176,9 +193,9 @@ class CounterTrackController extends TrackController<Config, Data> {
           lastValues: new Float64Array(numRows),
           totalDeltas: new Float64Array(numRows),
           rate: new Float64Array(numRows),
-        };
+        });
 
-        const it = queryRes.iter({
+       const it = queryRes.iter({
           'tsq': LONG,
           'lastId': NUM,
           'minValue': NUM,
@@ -211,7 +228,7 @@ class CounterTrackController extends TrackController<Config, Data> {
 
         return data;
       },
-      () => this.cancelData(),
+      () => data,
     );
 
     return result;

--- a/ui/src/tracks/process_summary/index.ts
+++ b/ui/src/tracks/process_summary/index.ts
@@ -20,7 +20,7 @@ import {NUM} from '../../common/query_result';
 import {TPDuration, TPTime} from '../../common/time';
 import {TrackData} from '../../common/track_data';
 import {LIMIT} from '../../common/track_data';
-import {TrackController} from '../../controller/track_controller';
+import {DynamicTable, TrackController} from '../../controller/track_controller';
 import {checkerboardExcept} from '../../frontend/checkerboard';
 import {globals} from '../../frontend/globals';
 import {NewTrackArgs, Track} from '../../frontend/track';
@@ -44,14 +44,17 @@ export interface Config {
 class ProcessSummaryTrackController extends TrackController<Config, Data> {
   static readonly kind = PROCESS_SUMMARY_TRACK;
   private setup = false;
+  private window = DynamicTable.NONE;
+  private span = DynamicTable.NONE;
+  private processSliceView = DynamicTable.NONE;
 
   async onBoundsChange(start: TPTime, end: TPTime, resolution: TPDuration):
       Promise<Data> {
     assertFalse(resolution === 0n, 'Resolution cannot be 0');
 
     if (this.setup === false) {
-      await this.query(
-          `create virtual table ${this.tableName('window')} using window;`);
+      this.window = this.createDynamicTable('window',
+          (name) => `create virtual table ${name} using window;`);
 
       let utids = [this.config.utid];
       if (this.config.upid) {
@@ -65,22 +68,22 @@ class ProcessSummaryTrackController extends TrackController<Config, Data> {
 
       const trackQuery = await this.query(
           `select id from thread_track where utid in (${utids.join(',')})`);
-      const tracks = [];
+      const tracks: number[] = [];
       for (const it = trackQuery.iter({id: NUM}); it.valid(); it.next()) {
         tracks.push(it.id);
       }
 
-      const processSliceView = this.tableName('process_slice_view');
-      await this.query(
-          `create view ${processSliceView} as ` +
+      this.processSliceView = this.createDynamicView('process_slice_view',
+        (name) => `create view ${name} as ` +
           // 0 as cpu is a dummy column to perform span join on.
           `select ts, dur/${utids.length} as dur ` +
           `from slice s ` +
           `where depth = 0 and track_id in ` +
           `(${tracks.join(',')})`);
-      await this.query(`create virtual table ${this.tableName('span')}
-          using span_join(${processSliceView},
-                          ${this.tableName('window')});`);
+      this.span = this.createDynamicTable('span',
+         (name, processSliceView, window) => `create virtual table ${name}
+          using span_join(${processSliceView}, ${window});`,
+        this.processSliceView, this.window);
       this.setup = true;
     }
 
@@ -90,7 +93,7 @@ class ProcessSummaryTrackController extends TrackController<Config, Data> {
     const windowStart = BigintMath.quant(start, bucketSize);
     const windowDur = BigintMath.max(1n, end - windowStart);
 
-    await this.query(`update ${this.tableName('window')} set
+    await this.window.query((window) => `update ${window} set
       window_start=${windowStart},
       window_dur=${windowDur},
       quantum=${bucketSize}
@@ -105,41 +108,43 @@ class ProcessSummaryTrackController extends TrackController<Config, Data> {
     const duration = end - start;
     const numBuckets = Math.min(Number(duration / bucketSize), LIMIT);
 
-    const query = `select
+    const sql = (span: string) => `select
       quantum_ts as bucket,
       sum(dur)/cast(${bucketSize} as float) as utilization
-      from ${this.tableName('span')}
+      from ${span}
       group by quantum_ts
       limit ${LIMIT}`;
 
-    const summary: Data = {
-      start,
-      end,
-      resolution,
-      length: numBuckets,
-      bucketSize,
-      utilizations: new Float64Array(numBuckets),
-    };
+    const result = await this.span.query(sql, (queryRes) => {
+      const summary: Data = {
+        start,
+        end,
+        resolution,
+        length: numBuckets,
+        bucketSize,
+        utilizations: new Float64Array(numBuckets),
+      };
 
-    const queryRes = await this.query(query);
-    const it = queryRes.iter({bucket: NUM, utilization: NUM});
-    for (; it.valid(); it.next()) {
-      const bucket = it.bucket;
-      if (bucket > numBuckets) {
-        continue;
+      const it = queryRes.iter({bucket: NUM, utilization: NUM});
+      for (; it.valid(); it.next()) {
+        const bucket = it.bucket;
+        if (bucket > numBuckets) {
+          continue;
+        }
+        summary.utilizations[bucket] = it.utilization;
       }
-      summary.utilizations[bucket] = it.utilization;
-    }
 
-    return summary;
+      return summary;
+    }, () => this.cancelData());
+
+    return result;
   }
 
   onDestroy(): void {
-    if (this.setup) {
-      this.query(`drop table if exists ${this.tableName('window')}`);
-      this.query(`drop table if exists ${this.tableName('span')}`);
-      this.setup = false;
-    }
+    this.span.drop();
+    this.processSliceView.drop();
+    this.window.drop();
+    this.setup = false;
   }
 }
 

--- a/ui/src/tracks/process_summary/index.ts
+++ b/ui/src/tracks/process_summary/index.ts
@@ -115,15 +115,23 @@ class ProcessSummaryTrackController extends TrackController<Config, Data> {
       group by quantum_ts
       limit ${LIMIT}`;
 
+    // Default to an empty summary in case the query fails,
+    // e.g. on the track being filtered out
+    const summary: Data = {
+      start,
+      end,
+      resolution,
+      length: 0,
+      bucketSize,
+      utilizations: Float64Array.of(),
+    };
+
     const result = await this.span.query(sql, (queryRes) => {
-      const summary: Data = {
-        start,
-        end,
-        resolution,
+      // Fill in the summary from the query results
+      Object.assign(summary, {
         length: numBuckets,
-        bucketSize,
         utilizations: new Float64Array(numBuckets),
-      };
+      });
 
       const it = queryRes.iter({bucket: NUM, utilization: NUM});
       for (; it.valid(); it.next()) {
@@ -135,7 +143,7 @@ class ProcessSummaryTrackController extends TrackController<Config, Data> {
       }
 
       return summary;
-    }, () => this.cancelData());
+    }, () => summary);
 
     return result;
   }


### PR DESCRIPTION
The process summary tracks can have dynamically defined tables that they create dropped during the sequence of asynchronous initialization steps in which they create those tables and query them.

Implement an abstraction to simplify the management of these tables:
- track the created table and existence thereof
- easily drop the table on destruction of the track controller
- execute queries on the table if and only if it exists, with fall-back options for when it doesn't

Apply the DynamicTable mechanism to manage dynamic tables for the process summary tracks and also the counter tracks that previously neglected to drop their tables (thus fixing a latent bug).

This PR fixes issue android-graphics/sokatoa#2317.

----

To test:

1. Open a capture that has Perfetto data.
2. Filter out all tracks except for the Memory Usage group of tracks. In particular, it's important to filter out all process track groups.
3. See that the timeline is greatly reduced in the number of tracks (there should now be a half dozen or so only) and there are no errors reported.
4. Close and re-open the capture.
5. Verify that it looks as it did at step 3 and there are no errors reported.