### PR TITLE
Add Control Mod to Track Group Selection

### DIFF
--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -188,6 +188,10 @@ export class TrackGroupPanel extends Panel<Attrs> {
         m(`.shell[draggable=true]`,
           {
             onclick: (e: MouseEvent) => {
+              if (!e.ctrlKey) {
+                globals.dispatch(
+                  Actions.clearTrackAndGroupSelection({}));
+              }
               globals.dispatch(
                 Actions.toggleTrackGroupSelection(
                   {trackGroupId: attrs.trackGroupId}));

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -188,7 +188,7 @@ export class TrackGroupPanel extends Panel<Attrs> {
         m(`.shell[draggable=true]`,
           {
             onclick: (e: MouseEvent) => {
-              if (!e.ctrlKey) {
+              if (!(navigator.userAgent.includes('Mac')? e.metaKey : e.ctrlKey)) {
                 globals.dispatch(
                   Actions.clearTrackAndGroupSelection({}));
               }

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -184,7 +184,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
         {
           class: `${highlightClass} ${dragClass} ${dropClass} ${globals.state.selectedTrackIds.has(attrs.trackState.id)? 'selected': ''}`,
           onclick: (e: MouseEvent)=>{
-            if (!e.ctrlKey) {
+            if (!(navigator.userAgent.includes('Mac')? e.metaKey : e.ctrlKey)) {
               globals.dispatch(
                 Actions.clearTrackAndGroupSelection({}));
             }


### PR DESCRIPTION
Track Groups did not previously act the same as Tracks when it came to selection.  Control modifier should now preserve selection.