### PR TITLE
prevent the webpage default behavior when dragging in the track content

### DIFF
--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -318,7 +318,7 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
           '.scroll-limiter',
           m('canvas.main-canvas'),
           ),
-      m('.panels', children),
+      m('.panels', {ondragstart: (e: DragEvent) => e.preventDefault()}, children),
     ];
   }
 

--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -318,7 +318,7 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
           '.scroll-limiter',
           m('canvas.main-canvas'),
           ),
-      m('.panels', {ondragstart: (e: DragEvent) => e.preventDefault()}, children),
+      m('.panels', children),
     ];
   }
 

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -34,7 +34,7 @@ import {
 } from './icons';
 import {Panel, PanelSize} from './panel';
 import {Track} from './track';
-import {TrackButton, TrackContent, checkTrackForResizability, resizeTrack} from './track_panel';
+import {EMPTY_IMAGE_DATA, TrackButton, TrackContent, checkTrackForResizability, resizeTrack} from './track_panel';
 import {trackRegistry} from './track_registry';
 import {drawVerticalLineAtTime} from './vertical_line_helper';
 import {getActiveVsyncData, renderVsyncColumns} from './vsync_helper';
@@ -65,7 +65,7 @@ export class TrackGroupPanel extends Panel<Attrs> {
     super();
 
     this.transparentImage =new Image();
-    this.transparentImage.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
+    this.transparentImage.src = EMPTY_IMAGE_DATA;
     this.trackGroupId = attrs.attrs.trackGroupId;
     const trackCreator = trackRegistry.get(this.summaryTrackState.kind);
     const engineId = this.summaryTrackState.engineId;

--- a/ui/src/frontend/track_group_panel.ts
+++ b/ui/src/frontend/track_group_panel.ts
@@ -51,6 +51,7 @@ export class TrackGroupPanel extends Panel<Attrs> {
   private summaryTrack: Track|undefined;
   private dragging = false;
   private dropping: 'before'|'after'|undefined = undefined;
+  private transparentImage?:HTMLImageElement;
   // private overFlown = false;
 
   // Caches the last state.trackGroups[this.trackGroupId].
@@ -62,6 +63,9 @@ export class TrackGroupPanel extends Panel<Attrs> {
 
   constructor(protected attrs: m.CVnode<Attrs>) {
     super();
+
+    this.transparentImage =new Image();
+    this.transparentImage.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
     this.trackGroupId = attrs.attrs.trackGroupId;
     const trackCreator = trackRegistry.get(this.summaryTrackState.kind);
     const engineId = this.summaryTrackState.engineId;
@@ -264,8 +268,12 @@ export class TrackGroupPanel extends Panel<Attrs> {
       e.stopPropagation();
       globals.rafScheduler.scheduleFullRedraw();
       dataTransfer.effectAllowed = 'move';
+      dataTransfer.items.clear();
+      dataTransfer.clearData();
       dataTransfer.setData('perfetto/track/' + this.trackGroupId, `${this.trackGroupId}`);
-      dataTransfer.setDragImage(new Image(), 0, 0);
+      if (this.transparentImage) {
+        dataTransfer.setDragImage(this.transparentImage, 0, 0);
+      }
   }
 
   ondragend() {

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -32,6 +32,8 @@ import {drawVerticalLineAtTime} from './vertical_line_helper';
 import {getActiveVsyncData, renderVsyncColumns} from './vsync_helper';
 import {SCROLLING_TRACK_GROUP, getContainingTrackIds} from '../common/state';
 
+
+export const EMPTY_IMAGE_DATA = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
 function isPinned(id: string) {
   return globals.state.pinnedTracks.indexOf(id) !== -1;
 }
@@ -129,7 +131,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
     this.attrs = vnode.attrs;
 
     this.transparentImage =new Image();
-    this.transparentImage.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
+    this.transparentImage.src = EMPTY_IMAGE_DATA;
     if (this.attrs) {
       this.defaultHeight =
         this.attrs.track.getHeight() / this.attrs.trackState.scaleFactor;

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -433,6 +433,7 @@ export class TrackContent implements m.ClassComponent<TrackContentAttrs> {
             globals.rafScheduler.scheduleRedraw();
           },
           onmousedown: (e: PerfettoMouseEvent) => {
+            e.preventDefault();
             this.mouseDownX = e.layerX;
             this.mouseDownY = e.layerY;
           },

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -445,9 +445,6 @@ export class TrackContent implements m.ClassComponent<TrackContentAttrs> {
             this.mouseDownX = e.layerX;
             this.mouseDownY = e.layerY;
           },
-          ondragstart: (e:DragEvent) => {
-            e.preventDefault();
-          },
           onmouseup: (e: PerfettoMouseEvent) => {
             if (this.mouseDownX === undefined ||
                 this.mouseDownY === undefined) {

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -123,8 +123,13 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
   private attrs?: TrackShellAttrs;
   private defaultHeight?: number;
 
+  private transparentImage?: HTMLImageElement;
+
   oninit(vnode: m.Vnode<TrackShellAttrs>) {
     this.attrs = vnode.attrs;
+
+    this.transparentImage =new Image();
+    this.transparentImage.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
     if (this.attrs) {
       this.defaultHeight =
         this.attrs.track.getHeight() / this.attrs.trackState.scaleFactor;
@@ -322,9 +327,13 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       this.dragging = true;
       e.stopPropagation();
       globals.rafScheduler.scheduleFullRedraw();
-        dataTransfer.effectAllowed = 'move';
-        dataTransfer.setData('perfetto/track/' + this.attrs!.trackState.id, `${this.attrs!.trackState.id}`);
-        dataTransfer.setDragImage(new Image(), 0, 0);
+      dataTransfer.effectAllowed = 'move';
+      dataTransfer.items.clear();
+      dataTransfer.clearData();
+      dataTransfer.setData('perfetto/track/' + this.attrs!.trackState.id, `${this.attrs!.trackState.id}`);
+      if (this.transparentImage) {
+        dataTransfer.setDragImage(this.transparentImage, 0, 0);
+      }
   }
 
   ondragend() {
@@ -433,9 +442,11 @@ export class TrackContent implements m.ClassComponent<TrackContentAttrs> {
             globals.rafScheduler.scheduleRedraw();
           },
           onmousedown: (e: PerfettoMouseEvent) => {
-            e.preventDefault();
             this.mouseDownX = e.layerX;
             this.mouseDownY = e.layerY;
+          },
+          ondragstart: (e:DragEvent) => {
+            e.preventDefault();
           },
           onmouseup: (e: PerfettoMouseEvent) => {
             if (this.mouseDownX === undefined ||

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -130,7 +130,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
   oninit(vnode: m.Vnode<TrackShellAttrs>) {
     this.attrs = vnode.attrs;
 
-    this.transparentImage =new Image();
+    this.transparentImage = new Image();
     this.transparentImage.src = EMPTY_IMAGE_DATA;
     if (this.attrs) {
       this.defaultHeight =

--- a/ui/src/frontend/viewer_page.ts
+++ b/ui/src/frontend/viewer_page.ts
@@ -370,6 +370,11 @@ class TraceViewer implements m.ClassComponent<TraceViewerAttrs> {
                 }
                 globals.makeSelection(Actions.deselect({}));
               },
+              ondragstart: (e :DragEvent)=>{
+                if (!(e.dataTransfer && e.dataTransfer.types.find((format)=>format.startsWith('perfetto/')))) {
+                  e.preventDefault();
+                }
+              },
             },
             m('.overview-panel-container', m(PanelContainer, {
                 doesScroll: false,

--- a/ui/src/frontend/viewer_page.ts
+++ b/ui/src/frontend/viewer_page.ts
@@ -370,7 +370,7 @@ class TraceViewer implements m.ClassComponent<TraceViewerAttrs> {
                 }
                 globals.makeSelection(Actions.deselect({}));
               },
-              ondragstart: (e :DragEvent)=>{
+              ondragstart: (e: DragEvent)=>{
                 if (!(e.dataTransfer && e.dataTransfer.types.find((format)=>format.startsWith('perfetto/')))) {
                   e.preventDefault();
                 }


### PR DESCRIPTION
#### What it does
Perfetto side fix for https://github.com/android-graphics/sokatoa/issues/2392
prevents webpage default behavior when dragging in the track content.  This was needed because the default behavior was dragging text content stopping the drag within the track.
#### How to test

1. Drag Select from left of search in timeline to the main content of the timeline
2. Search and some timeline headers should be highlighted
3. Try to drag select some content in the timeline
4. You're drag in the timeline should not be interrupted in this PR.  Try both left to right and right to left.