### PR TITLE
Add plugin support for aggregation controllers and support selecting the same area twice

### DIFF
--- a/ui/src/common/plugin_api.ts
+++ b/ui/src/common/plugin_api.ts
@@ -18,7 +18,7 @@ import {TrackControllerFactory} from '../controller/track_controller';
 import {TrackCreator} from '../frontend/track';
 import {Selection} from './state';
 import {CustomButtonArgs} from '../frontend/button_registry';
-import {CustomAggregateControllerArgs} from '../frontend/aggregation_registry';
+import {AggregateControllerArgs} from '../frontend/aggregation_registry';
 
 export {EngineProxy} from '../common/engine';
 export {
@@ -122,8 +122,8 @@ export interface PluginContext {
     onTrackSelectionChange:
       (trackIds: string[], trackGroupIds: string[]) => void): void;
 
-  registerAggregateController(
-    aggControlArgs: CustomAggregateControllerArgs):void;
+  registerAggregationController(
+    aggControlArgs: AggregateControllerArgs):void;
 }
 
 export interface PluginInfo {

--- a/ui/src/common/plugin_api.ts
+++ b/ui/src/common/plugin_api.ts
@@ -18,6 +18,7 @@ import {TrackControllerFactory} from '../controller/track_controller';
 import {TrackCreator} from '../frontend/track';
 import {Selection} from './state';
 import {CustomButtonArgs} from '../frontend/button_registry';
+import {CustomAggregateControllerArgs} from '../frontend/aggregation_registry';
 
 export {EngineProxy} from '../common/engine';
 export {
@@ -120,6 +121,9 @@ export interface PluginContext {
   registerOnTrackSelectionChange(
     onTrackSelectionChange:
       (trackIds: string[], trackGroupIds: string[]) => void): void;
+
+  registerAggregateController(
+    aggControlArgs: CustomAggregateControllerArgs):void;
 }
 
 export interface PluginInfo {

--- a/ui/src/common/plugins.ts
+++ b/ui/src/common/plugins.ts
@@ -30,6 +30,7 @@ import {
 import {Registry} from './registry';
 import {Selection} from './state';
 import {CustomButton, CustomButtonArgs, customButtonRegistry} from '../frontend/button_registry';
+import {CustomAggregateControllerArgs, customAggregateControllerRegistry} from '../frontend/aggregation_registry';
 
 // Every plugin gets its own PluginContext. This is how we keep track
 // what each plugin is doing and how we can blame issues on particular
@@ -73,6 +74,13 @@ export class PluginContextImpl implements PluginContext {
       onTrackSelectionChange:
         (trackIds: string[], trackGroupIds: string[]) => void) {
     this.onTrackSelectionChange = onTrackSelectionChange;
+  }
+
+  registerAggregateController(
+    aggControlArgs: CustomAggregateControllerArgs,
+  ) {
+    customAggregateControllerRegistry
+      .register(aggControlArgs);
   }
 
   registerCustomButton(button: CustomButtonArgs): void {

--- a/ui/src/common/plugins.ts
+++ b/ui/src/common/plugins.ts
@@ -30,7 +30,7 @@ import {
 import {Registry} from './registry';
 import {Selection} from './state';
 import {CustomButton, CustomButtonArgs, customButtonRegistry} from '../frontend/button_registry';
-import {CustomAggregateControllerArgs, customAggregateControllerRegistry} from '../frontend/aggregation_registry';
+import {AggregateControllerArgs, aggregateControllerRegistry} from '../frontend/aggregation_registry';
 
 // Every plugin gets its own PluginContext. This is how we keep track
 // what each plugin is doing and how we can blame issues on particular
@@ -76,10 +76,10 @@ export class PluginContextImpl implements PluginContext {
     this.onTrackSelectionChange = onTrackSelectionChange;
   }
 
-  registerAggregateController(
-    aggControlArgs: CustomAggregateControllerArgs,
+  registerAggregationController(
+    aggControlArgs: AggregateControllerArgs,
   ) {
-    customAggregateControllerRegistry
+    aggregateControllerRegistry
       .register(aggControlArgs);
   }
 

--- a/ui/src/controller/aggregation/aggregation_controller.ts
+++ b/ui/src/controller/aggregation/aggregation_controller.ts
@@ -59,6 +59,8 @@ export abstract class AggregationController extends Controller<'main'> {
   run() {
     const selection = globals.state.currentSelection;
     if (selection === null || selection.kind !== 'AREA') {
+      // Update Area Handler to be cleared
+      this.areaSelectionHandler.getAreaChange();
       publishAggregateData({
         data: {
           tabName: this.getTabName(),

--- a/ui/src/controller/area_selection_handler.ts
+++ b/ui/src/controller/area_selection_handler.ts
@@ -21,6 +21,7 @@ export class AreaSelectionHandler {
   getAreaChange(): [boolean, AreaById|undefined] {
     const currentSelection = globals.state.currentSelection;
     if (currentSelection === null || currentSelection.kind !== 'AREA') {
+      this.previousArea = undefined;
       return [false, undefined];
     }
 

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {customAggregateControllerRegistry} from '../frontend/aggregation_registry';
 import {BigintMath} from '../base/bigint_math';
 import {assertExists, assertTrue} from '../base/logging';
 import {
@@ -311,6 +312,13 @@ export class TraceController extends Controller<States> {
           'frame_aggregation',
           FrameAggregationController,
           {engine, kind: 'frame_aggregation'}));
+          for (const customController of
+            customAggregateControllerRegistry.values()) {
+              childControllers.push(Child(
+                customController.kind,
+                customController.controllerFactory,
+                {engine, kind: customController.kind}));
+          }
         childControllers.push(Child('search', SearchController, {
           engine,
           app: globals,

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {customAggregateControllerRegistry} from '../frontend/aggregation_registry';
+import {aggregateControllerRegistry} from '../frontend/aggregation_registry';
 import {BigintMath} from '../base/bigint_math';
 import {assertExists, assertTrue} from '../base/logging';
 import {
@@ -313,7 +313,7 @@ export class TraceController extends Controller<States> {
           FrameAggregationController,
           {engine, kind: 'frame_aggregation'}));
           for (const customController of
-            customAggregateControllerRegistry.values()) {
+            aggregateControllerRegistry.values()) {
               childControllers.push(Child(
                 customController.kind,
                 customController.controllerFactory,

--- a/ui/src/frontend/aggregation_registry.ts
+++ b/ui/src/frontend/aggregation_registry.ts
@@ -18,9 +18,9 @@ import {Registry} from '../common/registry';
 import {ControllerFactory} from '../controller/controller';
 import {AggregationControllerArgs} from '../controller/aggregation/aggregation_controller';
 
-export interface CustomAggregateControllerArgs {
+export interface AggregateControllerArgs {
     kind: string,
     controllerFactory: ControllerFactory<AggregationControllerArgs>;
 }
-export const customAggregateControllerRegistry =
- Registry.kindRegistry<CustomAggregateControllerArgs>();
+export const aggregateControllerRegistry =
+ Registry.kindRegistry<AggregateControllerArgs>();

--- a/ui/src/frontend/aggregation_registry.ts
+++ b/ui/src/frontend/aggregation_registry.ts
@@ -1,0 +1,26 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// import {AggregationController}
+// from '../controller/aggregation/aggregation_controller';
+import {Registry} from '../common/registry';
+import {ControllerFactory} from '../controller/controller';
+import {AggregationControllerArgs} from '../controller/aggregation/aggregation_controller';
+
+export interface CustomAggregateControllerArgs {
+    kind: string,
+    controllerFactory: ControllerFactory<AggregationControllerArgs>;
+}
+export const customAggregateControllerRegistry =
+ Registry.kindRegistry<CustomAggregateControllerArgs>();


### PR DESCRIPTION
Required for https://github.com/android-graphics/sokatoa/pull/2828
Adds plugin support for new aggregation controls, which are used to display area selections.  
