### PR TITLE
Do not move to account for pinned track addition

### DIFF
--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -234,24 +234,7 @@ class TrackShell implements m.ClassComponent<TrackShellAttrs> {
           ...this.getTrackShellButtons(attrs),
           attrs.track.getContextMenu(),
           m(TrackButton, {
-            action: (e) => {
-              // Scroll timeline by height of toggledPinnedTrack
-              const toBePinned =
-                !globals.state.pinnedTracks.includes(attrs.trackState.id);
-              if (e.currentTarget && e.currentTarget instanceof Element) {
-                const trackShell = e.currentTarget.closest('.track-shell');
-                if (trackShell) {
-                  let toScroll = trackShell.clientHeight;
-                  if (!toBePinned) {
-                    toScroll *= -1;
-                  }
-                  const parentScrollPanel = trackShell.closest('.scrolling-panel-container');
-                  if (parentScrollPanel) {
-                    parentScrollPanel.scroll(0,
-                      parentScrollPanel.scrollTop + toScroll);
-                  }
-                }
-              }
+            action: () => {
               globals.dispatch(
                   Actions.toggleTrackPinned({trackId: attrs.trackState.id}));
             },


### PR DESCRIPTION
With the changes to allow pinned tracks in a resizable group we no longer need to plan for pinned tracks moving unpinned tracks since they are both a set size unless resized.
