### PR TITLE
Fix canvas widths with fractional scaling

### DIFF
--- a/ui/src/frontend/panel_container.ts
+++ b/ui/src/frontend/panel_container.ts
@@ -356,9 +356,16 @@ export class PanelContainer implements m.ClassComponent<Attrs> {
     }
 
     const dpr = window.devicePixelRatio;
-    ctx.canvas.width = this.parentWidth * dpr;
-    ctx.canvas.height = this.canvasHeight * dpr;
+    ctx.canvas.width = Math.floor(this.parentWidth * dpr);
+    ctx.canvas.height = Math.floor(this.canvasHeight * dpr);
     ctx.scale(dpr, dpr);
+
+    // When using fractional scaling (e.g. 110%), Browsers may round sub-pixel
+    // values differently for canvases even if they are meant to have the same
+    // dimensions, which can lead to slight misalignments between multiple
+    // canvases. To enforce consistent alignment, we set the CSS width
+    // explicitly to the parent's width rounded down to an integer.
+    ctx.canvas.style.width = `${Math.floor(this.parentWidth)}px`;
   }
 
   private repositionCanvas() {


### PR DESCRIPTION
#### What it does

Explicitly set a width on panel canvases to avoid rounding issues when using fractional scaling. 

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
