### PR TITLE
Ensure correct architecture for trace_processor_shell on macOS

### DIFF
--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -271,8 +271,19 @@ config("default") {
     ]
   } else if (current_cpu == "arm64") {
     cflags += [ "-fno-omit-frame-pointer" ]
+
+    if (is_mac && is_clang && enable_perfetto_trace_processor_sqlite && !is_wasm) {
+      cflags += [ "--target=arm64-apple-darwin" ]
+      ldflags += [ "--target=arm64-apple-darwin" ]
+    }
   } else if (current_cpu == "x64") {
     cflags += [ "-fno-omit-frame-pointer" ]  # For perf profiling.
+
+    if (is_mac && is_clang && enable_perfetto_trace_processor_sqlite && !is_wasm) {
+      cflags += [ "--target=x64-apple-darwin" ]
+      ldflags += [ "--target=x64-apple-darwin" ]
+    }
+
     if (enable_perfetto_x64_cpu_opt) {
       # When updating these flags, the CheckCpuOptimizations() in utils.cc must
       # be updated accordingly.

--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -280,8 +280,8 @@ config("default") {
     cflags += [ "-fno-omit-frame-pointer" ]  # For perf profiling.
 
     if (is_mac && is_clang && enable_perfetto_trace_processor_sqlite && !is_wasm) {
-      cflags += [ "--target=x64-apple-darwin" ]
-      ldflags += [ "--target=x64-apple-darwin" ]
+      cflags += [ "--target=x86_64-apple-darwin" ]
+      ldflags += [ "--target=x86_64-apple-darwin" ]
     }
 
     if (enable_perfetto_x64_cpu_opt) {


### PR DESCRIPTION
Use explicit `clang` arguments for the compiler and linker to build for the host architecture, to avoid macOS builds on ARM that build the host application for ARM platform bundling a `trace_processor_shell` that requires Rosetta.

The WASM build fails when attempting to target ARM so it remains x64.

For android-graphics/sokatoa#2861

