### PR TITLE
Handle failures in initialization of filtered-out async slice tracks

### DIFF
--- a/ui/src/controller/track_controller.ts
+++ b/ui/src/controller/track_controller.ts
@@ -362,6 +362,17 @@ export abstract class TrackController<
                 this.publish(data);
               }
             })
+            .catch((error) => {
+              if (!globals.state.tracks[this.trackId]) {
+                // The host application filtered this track out, so assume that
+                // the error was an assertion failure in asynchronous
+                // on-bounds-change processing that interleaved with the
+                // removal of the track from global state
+                this.queuedRequest = false;
+                return;
+              }
+              throw error;
+            })
             .finally(() => {
               this.requestingData = false;
               if (this.queuedRequest) {


### PR DESCRIPTION
The initial bounds-change handling of an async slice track performs multiple queries asynchronously, in sequence, awaiting the results of each in turn. During one of those waits, a host application embedding Perfetto can filter that track out so that it is no longer in the tracks table in global state and then accessing that state to formulate the next SQL query throws an exception. Trap that exception and bail the initialization of the track controller.

For android-graphics/soktatoa#2949
