### PR TITLE
Build for all commits to the branch

### DIFF
--- a/.github/workflows/build-and-publish-perfetto-ui.yml
+++ b/.github/workflows/build-and-publish-perfetto-ui.yml
@@ -6,8 +6,6 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    paths:
-      - 'ui/**'
     branches:
       - reuse_timeline
 


### PR DESCRIPTION
The ui filter was preventing non ui changes from triggering a perfetto build. But we need a new build for any change, regardless if the ui part of the build is changing or not. The issue was observed with an sdk only change.

<!--
Thank you for your Pull Request. Please provide a description and review the requirements below.

***
Please make sure that you set 'eclipsesource/perfetto' as the base repository with 'reuse_timeline' as base branch for this pull request. By default, GitHub uses the upstream repository from Google as base repository but in 99% of the cases you'll want your contribution to go into this fork.
***

If you have discovered a security vulnerability in this project, please report it privately. Do not disclose it as a public issue. This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released. Please disclose it at https://github.com/eclipsesource/perfetto/security/advisories/new.
-->

#### What it does

Changing the github setup to unconditionally build any commit to the reuse_timeline branch, not just for ui changes.

#### How to test

See if once this PR is merged, if a build is automatically started.

