### PR TITLE
Fix trace processor build for macOS 15.4 SDK

### DIFF
--- a/buildtools/BUILD.gn
+++ b/buildtools/BUILD.gn
@@ -1242,6 +1242,9 @@ config("zlib_config") {
     cflags += [
       "-Wno-unknown-warning-option",
       "-Wno-deprecated-non-prototype",
+
+      # zlib redefines macros
+      "-Wno-macro-redefined",
     ]
   }
 }

--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -65,7 +65,9 @@ config("extra_warnings") {
   # Disable variadic macro warning as we make extensive use of them in trace
   # processor and client API.
   if (is_clang) {
-    if (!is_fuzzer) {
+    # Only enable -Weverything on hermetic clang as system clang might be quite
+    # out of date.
+    if (is_hermetic_clang && current_toolchain == host_toolchain && !is_fuzzer) {
       # Disable Weverything on fuzzers to avoid breakages when new versions of
       # clang are rolled into OSS-fuzz.
       cflags += [ "-Weverything" ]
@@ -86,6 +88,10 @@ config("extra_warnings") {
       "-Wno-unknown-sanitizers",
       "-Wno-unknown-warning-option",
       "-Wno-unsafe-buffer-usage",
+
+      # TODO(primiano): -Wswitch-default could be useful but will require a mass
+      # codebase cleanup.
+      "-Wno-switch-default",
     ]
   } else if (!is_clang && !is_win) {
     # Use return std::move(...) for compatibility with old GCC compilers.
@@ -216,7 +222,7 @@ config("default") {
   }
 
   # Treat warnings as errors, but give up on fuzzer builds.
-  if (!is_fuzzer) {
+  if (!is_fuzzer && is_hermetic_clang) {
     if (is_win) {
       cflags += [ "/WX" ]
     } else {

--- a/tools/install-build-deps
+++ b/tools/install-build-deps
@@ -274,7 +274,7 @@ BUILD_DEPS_HOST = [
     # If updating the version, also update bazel/deps.bzl.
     Dependency('buildtools/zlib',
                'https://android.googlesource.com/platform/external/zlib.git',
-               '6d3f6aa0f87c9791ca7724c279ef61384f331dfd', 'all', 'all'),
+               'f29fc757b1f27c182f36790eb0ccc6cf8ec27e8e', 'all', 'all'),
 
     # Linenoise, used only by trace_processor in standalone builds.
     # If updating the version, also update bazel/deps.bzl.


### PR DESCRIPTION
- backport fix for `-Weverything` including warnings incompatible with Perfetto from upstream
- also only use `-Werror` with hermetic clang installation

For android-graphics/sokatoa#3083
