### PR TITLE
Verbose Log Level Should show all logs

### DIFF
--- a/ui/src/common/empty_state.ts
+++ b/ui/src/common/empty_state.ts
@@ -164,7 +164,7 @@ export function createEmptyState(): State {
 
     logFilteringCriteria: {
       // The first two log priorities are ignored.
-      minimumLevel: 2,
+      minimumLevel: 0,
       tags: [],
       textEntry: '',
       hideNonMatching: true,

--- a/ui/src/frontend/logs_filters.ts
+++ b/ui/src/frontend/logs_filters.ts
@@ -18,8 +18,7 @@ import {Actions} from '../common/actions';
 import {globals} from './globals';
 
 export const LOG_PRIORITIES =
-    ['-', '-', 'Verbose', 'Debug', 'Info', 'Warn', 'Error', 'Fatal'];
-const IGNORED_STATES = 2;
+    ['Verbose', '', '', 'Debug', 'Info', 'Warn', 'Error', 'Fatal'];
 
 interface LogPriorityWidgetAttrs {
   options: string[];
@@ -44,10 +43,12 @@ class LogPriorityWidget implements m.ClassComponent<LogPriorityWidgetAttrs> {
   view(vnode: m.Vnode<LogPriorityWidgetAttrs>) {
     const attrs = vnode.attrs;
     const optionComponents = [];
-    for (let i = IGNORED_STATES; i < attrs.options.length; i++) {
+    for (let i = 0; i < attrs.options.length; i++) {
       const selected = i === attrs.selectedIndex;
-      optionComponents.push(
-          m('option', {value: i, selected}, attrs.options[i]));
+      if (attrs.options[i]) {
+        optionComponents.push(
+            m('option', {value: i, selected}, attrs.options[i]));
+      }
     }
     return m(
         'select',


### PR DESCRIPTION
#### What it does
@wpaul-samsung had a capture of Warzone that displayed Android Logs in the timeline, but the Android Logs Detail Panel didn't show them.  These logs had a logLevel of 0.  Perfetto's lowest level (Verbose) shows anything above a logLevel of 2.  So the Panel appeared but hid these logs.  

This PR makes Verbose show any log above a logLevel of 0.

![image](https://github.com/user-attachments/assets/20657695-345d-4bc6-85ce-9755f5cafa27)