### PR TITLE
Filter out NULL values in counter data

### DIFF
--- a/ui/src/tracks/counter/index.ts
+++ b/ui/src/tracks/counter/index.ts
@@ -93,7 +93,7 @@ class CounterTrackController extends TrackController<Config, Data> {
             value,
             delta
           from experimental_counter_dur
-          where track_id = ${this.config.trackId};
+          where track_id = ${this.config.trackId} and value is not null;
         `;
       } else {
         ddl = (counterView) => `


### PR DESCRIPTION
The code querying the counter tables does not expect non numerical values in the table.
We do get NULL values when the counter data source emitter sends in a NaN (double not a number) value as the counter value. Changing the insertion into the database to actually insert NaN's would change the perfetto behavior in a lot of different ways, hence this change just filters out the counter table. "Normal" counter data does not include NULL (NaN/Infinity, lack of value) cases, so this should only affect the display of already problematic cases.
It was seen with a perfetto trace generated by a Samsung S22, which is using a old version of the current driver known to have this issue.

The issue was not seen with the current main perfetto build, hence this does not need to be merged if we do rebase.
