### PR TITLE
Integrate upstream patches for Android Logs

### DIFF
--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -9099,6 +9099,17 @@ message LogMessage {
   optional uint64 source_location_iid = 1;
   // interned LogMessageBody.
   optional uint64 body_iid = 2;
+  enum Priority {
+    PRIO_UNSPECIFIED = 0;
+    PRIO_UNUSED = 1;
+    PRIO_VERBOSE = 2;
+    PRIO_DEBUG = 3;
+    PRIO_INFO = 4;
+    PRIO_WARN = 5;
+    PRIO_ERROR = 6;
+    PRIO_FATAL = 7;
+  }
+  optional Priority prio = 3;
 }
 
 // --------------------
@@ -9109,6 +9120,7 @@ message LogMessageBody {
   optional uint64 iid = 1;
   optional string body = 2;
 }
+
 // End of protos/perfetto/trace/track_event/log_message.proto
 
 // Begin of protos/perfetto/trace/track_event/source_location.proto

--- a/protos/perfetto/trace/track_event/log_message.proto
+++ b/protos/perfetto/trace/track_event/log_message.proto
@@ -23,6 +23,17 @@ message LogMessage {
   optional uint64 source_location_iid = 1;
   // interned LogMessageBody.
   optional uint64 body_iid = 2;
+  enum Priority {
+    PRIO_UNSPECIFIED = 0;
+    PRIO_UNUSED = 1;
+    PRIO_VERBOSE = 2;
+    PRIO_DEBUG = 3;
+    PRIO_INFO = 4;
+    PRIO_WARN = 5;
+    PRIO_ERROR = 6;
+    PRIO_FATAL = 7;
+  }
+  optional Priority prio = 3;
 }
 
 // --------------------

--- a/src/trace_processor/importers/proto/track_event_parser.cc
+++ b/src/trace_processor/importers/proto/track_event_parser.cc
@@ -38,6 +38,7 @@
 #include "src/trace_processor/util/proto_to_args_parser.h"
 #include "src/trace_processor/util/status_macros.h"
 
+#include "protos/perfetto/common/android_log_constants.pbzero.h"
 #include "protos/perfetto/trace/extension_descriptor.pbzero.h"
 #include "protos/perfetto/trace/interned_data/interned_data.pbzero.h"
 #include "protos/perfetto/trace/track_event/chrome_active_processes.pbzero.h"
@@ -1327,9 +1328,14 @@ class TrackEventParser::EventImporter {
           Variadic::Integer(source_location_decoder->line_number()));
     }
 
+    // The track event log message doesn't specify any priority. UI never
+    // displays priorities < 2 (VERBOSE in android). Let's make all the track
+    // event logs show up as INFO.
+    constexpr uint32_t kPriority =
+        protos::pbzero::AndroidLogPriority::PRIO_INFO;
     storage_->mutable_android_log_table()->Insert(
         {ts_, *utid_,
-         /*priority*/ 0,
+         /*priority*/ kPriority,
          /*tag_id*/ source_location_id, log_message_id});
 
     return util::OkStatus();

--- a/src/trace_processor/importers/proto/track_event_parser.h
+++ b/src/trace_processor/importers/proto/track_event_parser.h
@@ -92,6 +92,7 @@ class TrackEventParser {
   const StringId log_message_source_location_function_name_key_id_;
   const StringId log_message_source_location_file_name_key_id_;
   const StringId log_message_source_location_line_number_key_id_;
+  const StringId log_message_priority_id_;
   const StringId source_location_function_name_key_id_;
   const StringId source_location_file_name_key_id_;
   const StringId source_location_line_number_key_id_;

--- a/test/trace_processor/diff_tests/chrome/tests.py
+++ b/test/trace_processor/diff_tests/chrome/tests.py
@@ -361,11 +361,13 @@ class Chrome(TestSuite):
         }
         """),
         query="""
-        SELECT utid, tag, msg FROM android_logs;
+        SELECT utid, tag, msg, prio FROM android_logs;
         """,
+        # If the log_message_body doesn't have any priority, a default 4 (i.e.
+        # INFO) is assumed (otherwise the UI will not show the message).
         out=Csv("""
-        "utid","tag","msg"
-        1,"foo.cc:123","log message"
+        "utid","tag","msg","prio"
+        1,"foo.cc:123","log message",4
         """))
 
   def test_chrome_log_message_args(self):

--- a/test/trace_processor/diff_tests/chrome/tests.py
+++ b/test/trace_processor/diff_tests/chrome/tests.py
@@ -370,6 +370,62 @@ class Chrome(TestSuite):
         1,"foo.cc:123","log message",4
         """))
 
+  def test_chrome_log_message_priority(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 0
+          incremental_state_cleared: true
+          trusted_packet_sequence_id: 1
+          track_descriptor {
+            uuid: 12345
+            thread {
+              pid: 123
+              tid: 345
+            }
+            parent_uuid: 0
+            chrome_thread {
+              thread_type: THREAD_POOL_FG_WORKER
+            }
+          }
+        }
+
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 10
+          track_event {
+            track_uuid: 12345
+            categories: "cat1"
+            type: TYPE_INSTANT
+            name: "slice1"
+            log_message {
+                body_iid: 1
+                source_location_iid: 3
+                prio: PRIO_WARN
+            }
+          }
+          interned_data {
+            log_message_body {
+                iid: 1
+                body: "log message"
+            }
+            source_locations {
+                iid: 3
+                function_name: "func"
+                file_name: "foo.cc"
+                line_number: 123
+            }
+          }
+        }
+        """),
+        query="""
+        SELECT utid, tag, msg, prio FROM android_logs;
+        """,
+        out=Csv("""
+        "utid","tag","msg","prio"
+        1,"foo.cc:123","log message",5
+        """))
+
   def test_chrome_log_message_args(self):
     return DiffTestBlueprint(
         trace=TextProto(r"""


### PR DESCRIPTION
Cherry-pick two commits from upstream that recode certain application log messages as priority 4 (INFO) and adapt the UI to handle them.

For android-graphics/sokatoa#3106