### PR TITLE
fix description

### DIFF
--- a/ui/src/controller/track_decider.ts
+++ b/ui/src/controller/track_decider.ts
@@ -2367,7 +2367,7 @@ class TrackDecider {
 
     for (const [groupName, tracks] of metricTrackGroupings) {
       const groupId = this.lazyTrackGroup(groupName,
-        {description: `Results from calculation of the {$groupName} metric.`});
+        {description: `Results from calculation of the ${groupName} metric.`});
       // Don't create a group of just one track but do add
       // to a group if it already exists
       if (tracks.size < 2 && !groupId.exists()) {


### PR DESCRIPTION
Seen in a tooltip in sokatoa, the description used {$GroupName} instead of ${GroupName}, resulting of the text been shown without any replacement.

