### PR TITLE
ui: customizable minimum track height

### DIFF
--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -352,6 +352,15 @@ function onCssLoaded() {
     defaultValue: 'light',
   });
 
+  AppImpl.instance.settings.register({
+    id: 'track-height-min-px',
+    name: 'Track Height',
+    description:
+      'Minimum height of tracks in the trace viewer page, in pixels.',
+    schema: z.number().int().min(18),
+    defaultValue: 18,
+  });
+
   // Add command to toggle the theme.
   AppImpl.instance.commands.registerCommand({
     id: 'dev.perfetto.ToggleTheme',

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -30,6 +30,7 @@ import {HighPrecisionTimeSpan} from '../../base/high_precision_time_span';
 import {Icons} from '../../base/semantic_icons';
 import {TimeScale} from '../../base/time_scale';
 import {RequiredField} from '../../base/utils';
+import {AppImpl} from '../../core/app_impl';
 import {PerfStats, runningStatStr} from '../../core/perf_stats';
 import {raf} from '../../core/raf_scheduler';
 import {TraceImpl} from '../../core/trace_impl';
@@ -58,11 +59,15 @@ import {Popup} from '../../widgets/popup';
 import {Theme} from '../../public/theme';
 import {CodeSnippet} from '../../widgets/code_snippet';
 
-const TRACK_HEIGHT_MIN_PX = 18;
+const DEFAULT_TRACK_HEIGHT_MIN_PX = 18;
 
 function getTrackHeight(node: TrackNode, track?: TrackRenderer) {
   // Headless tracks have an effective height of 0.
   if (node.headless) return 0;
+
+  const TRACK_HEIGHT_MIN_PX =
+    (AppImpl.instance.settings.get('track-height-min-px')?.get() as number) ??
+    DEFAULT_TRACK_HEIGHT_MIN_PX;
 
   // Expanded summary tracks don't show any data, so make them a little more
   // compact to save space.


### PR DESCRIPTION
Tracks once occupied more vertical space, which can be more comfortable especially for users with vision and motor (pointer control) difficulties. To accommodate embedding applications and users with accessibility needs, add support for customization of the height of tracks via a new setting.

For android-graphics/sokatoa#3887

----

https://github.com/user-attachments/assets/334e0f87-ed47-4db1-a33e-ee29ba24ba87

