### PR TITLE
ui: add pf-button class to modal close button

### DIFF
--- a/ui/src/widgets/modal.ts
+++ b/ui/src/widgets/modal.ts
@@ -164,7 +164,7 @@ export class Modal implements m.ClassComponent<ModalAttrs> {
             m('h2', {id: 'mm-title'}, attrs.title),
           ),
           m(
-            'button[aria-label=Close Modal]',
+            'button.pf-button[aria-label=Close Modal]',
             {onclick: () => closeModal(attrs.key)},
             m(Icon, {icon: 'close'}),
           ),


### PR DESCRIPTION
Adds the `pf-button` class, which has a theme-appropriate specification for foreground color, to the button that closes modal dialogues.