### PR TITLE
ui: use the trace omnibox manager in command omnibox rendering

### DIFF
--- a/ui/src/frontend/help_modal.ts
+++ b/ui/src/frontend/help_modal.ts
@@ -79,6 +79,7 @@ class KeyMappingsHelp implements m.ClassComponent {
   }
 
   view(): m.Children {
+    const app = AppImpl.instance.trace ?? AppImpl.instance;
     return m(
       '.pf-help-modal',
       m('h2', 'Navigation'),
@@ -158,7 +159,7 @@ class KeyMappingsHelp implements m.ClassComponent {
       m('h2', 'Command Hotkeys'),
       m(
         'table',
-        AppImpl.instance.commands.commands
+        app.commands.commands
           .filter(({defaultHotkey}) => defaultHotkey)
           .sort((a, b) => a.name.localeCompare(b.name))
           .map(({defaultHotkey, name}) => {

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -177,7 +177,7 @@ export class UiMainPerTrace implements m.ClassComponent<UiMainPerTraceAttrs> {
 
   renderCommandOmnibox(): m.Children {
     // Fuzzy-filter commands by the filter string.
-    const {omnibox} = AppImpl.instance;
+    const omnibox = this.preferredApp.omnibox;
     const commands = this.preferredApp.commands;
     const filteredCmds = commands.fuzzyFilterCommands(omnibox.text);
 


### PR DESCRIPTION
Use the trace-specific omnibox manager, not the parent app omnibox manager, when rendering the command palette mode of the omnibox.

Also while we're in here, because our trace-specific omnibox enhancements are contributed in the same PR on upstream as the support for multiple open traces, and that support for multiple traces has trace-specific command managers, fix the help dialog to show the hotkeys for commands of the currently active trace instead of the app (which only has a small number of commands).

This will be a complete fix for the Sokatoa bug android-graphics/sokatoa#3976.