### PR TITLE
ui: separate modal dialog state by trace

### DIFF
--- a/ui/src/core/selection_manager.ts
+++ b/ui/src/core/selection_manager.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue, assertUnreachable} from '../base/logging';
+import {assertExists, assertTrue, assertUnreachable} from '../base/logging';
 import {
   Selection,
   Area,
@@ -35,6 +35,7 @@ import {SerializedSelection} from './state_serialization_schema';
 import {showModal} from '../widgets/modal';
 import {NUM, SqlValue, UNKNOWN} from '../trace_processor/query_result';
 import {SourceDataset, UnionDataset} from '../trace_processor/dataset';
+import {Trace} from '../public/trace';
 import {Track} from '../public/track';
 import {TimelineImpl} from './timeline';
 import {HighPrecisionTime} from '../base/high_precision_time';
@@ -60,6 +61,7 @@ export class SelectionManagerImpl implements SelectionManager {
     Selection,
     SelectionDetailsPanel
   >();
+  private _trace?: Trace;
   public readonly areaSelectionTabs: AreaSelectionTab[] = [];
 
   constructor(
@@ -70,6 +72,15 @@ export class SelectionManagerImpl implements SelectionManager {
     private scrollHelper: ScrollHelper,
     private onSelectionChange: (s: Selection, opts: SelectionOpts) => void,
   ) {}
+
+  get trace(): Trace {
+    return assertExists(this._trace);
+  }
+
+  setTrace(trace: Trace): void {
+    assertTrue(this._trace === undefined);
+    this._trace = trace;
+  }
 
   clearSelection(): void {
     this.setSelection({kind: 'empty'});
@@ -149,6 +160,7 @@ export class SelectionManagerImpl implements SelectionManager {
       }
     } catch (ex) {
       showModal({
+        owner: this.trace,
         title: 'Failed to restore the selected event',
         content: m(
           'div',

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -233,6 +233,11 @@ export class TraceImpl implements Trace {
     this.traceCtx = ctx;
     const traceUnloadTrash = ctx.trash;
 
+    if (pluginId === CORE_PLUGIN_ID) {
+      // Inject myself into the selection manager so that it can target modal dialogs
+      ctx.selectionMgr.setTrace(this);
+    }
+
     const childOmnibox = appImpl.omnibox.childFor(ctx);
     traceUnloadTrash.use(childOmnibox);
     this.omniboxMgr = childOmnibox;

--- a/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
@@ -776,6 +776,7 @@ export default class CoreCommands implements PerfettoPlugin {
         const json = localStorage.getItem(QUICKSAVE_LOCALSTORAGE_KEY);
         if (json === null) {
           showModal({
+            owner: ctx,
             title: 'Nothing saved in the quicksave slot',
             buttons: [{text: 'Dismiss'}],
           });

--- a/ui/src/frontend/help_modal.ts
+++ b/ui/src/frontend/help_modal.ts
@@ -25,10 +25,12 @@ import {
 } from '../base/keyboard_layout_map';
 import {KeyMapping} from './viewer_page/wasd_navigation_handler';
 import {raf} from '../core/raf_scheduler';
+import {App} from '../public/app';
 
-export function toggleHelp() {
+export function toggleHelp(app: App) {
   AppImpl.instance.analytics.logEvent('User Actions', 'Show help');
   return showModal({
+    owner: app,
     title: 'Perfetto Help',
     content: () => m(KeyMappingsHelp),
   });

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -37,7 +37,7 @@ import {checkHttpRpcConnection} from './rpc_http_dialog';
 import {maybeOpenTraceFromRoute} from './trace_url_handler';
 import {renderViewerPage} from './viewer_page/viewer_page';
 import {HttpRpcEngine} from '../trace_processor/http_rpc_engine';
-import {showModal} from '../widgets/modal';
+import {setDefaultOwnerFunction, showModal} from '../widgets/modal';
 import {IdleDetector} from './idle_detector';
 import {IdleDetectorWindow} from './idle_detector_interface';
 import {AppImpl} from '../core/app_impl';
@@ -268,6 +268,8 @@ function main() {
     startupCommandsSetting,
     enforceStartupCommandAllowlistSetting,
   });
+
+  setDefaultOwnerFunction(() => AppImpl.instance.trace ?? AppImpl.instance);
 
   // Load the css. The load is asynchronous and the CSS is not ready by the time
   // appendChild returns.

--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -184,7 +184,7 @@ export function postMessageHandler(messageEvent: MessageEvent) {
   }
 
   if (messageEvent.data === 'SHOW-HELP') {
-    toggleHelp();
+    toggleHelp(AppImpl.instance.trace ?? AppImpl.instance);
     return;
   }
 

--- a/ui/src/frontend/trace_share_utils.ts
+++ b/ui/src/frontend/trace_share_utils.ts
@@ -47,6 +47,7 @@ export async function shareTrace(trace: TraceImpl) {
       const traceUrl = await uploadTraceBlob(trace);
       const hash = await createPermalink(trace, traceUrl);
       showModal({
+        owner: trace,
         title: 'Permalink',
         content: m(CopyableLink, {
           url: `${self.location.origin}/#!/?s=${hash}`,
@@ -69,6 +70,7 @@ export async function shareTrace(trace: TraceImpl) {
           const hash = await createPermalink(trace, undefined);
           const urlWithHash = traceUrl.replace(STATE_HASH_PLACEHOLDER, hash);
           showModal({
+            owner: trace,
             title: 'Permalink',
             content: m(CopyableLink, {url: urlWithHash}),
           });
@@ -76,6 +78,7 @@ export async function shareTrace(trace: TraceImpl) {
       } else {
         // Trace is not sharable, has a URL, but no placeholder.
         showModal({
+          owner: trace,
           title: 'Cannot create permalink from external trace',
           content: m(
             '',
@@ -94,6 +97,7 @@ export async function shareTrace(trace: TraceImpl) {
       // Trace is not sharable and has no URL. Nothing we can do. Just tell the
       // user.
       showModal({
+        owner: trace,
         title: 'Cannot create permalink',
         content: m(
           'p',

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -91,7 +91,7 @@ export class UiMainPerTrace implements m.ClassComponent<UiMainPerTraceAttrs> {
       {
         id: 'dev.perfetto.ShowHelp',
         name: 'Show help',
-        callback: () => toggleHelp(),
+        callback: () => toggleHelp(this.preferredApp),
         defaultHotkey: '?',
       },
     ];
@@ -103,7 +103,7 @@ export class UiMainPerTrace implements m.ClassComponent<UiMainPerTraceAttrs> {
     // commands or anything in this state as they will be useless.
     if (trace === undefined) return;
     document.title = `${trace.traceInfo.traceTitle || 'Trace'} - Perfetto UI`;
-    this.maybeShowJsonWarning();
+    this.maybeShowJsonWarning(this.preferredApp);
   }
 
   private renderOmnibox(): m.Children {
@@ -385,7 +385,7 @@ export class UiMainPerTrace implements m.ClassComponent<UiMainPerTraceAttrs> {
         this.preferredApp.pages.renderPageForCurrentRoute(this.trace),
       ),
       m(CookieConsent),
-      maybeRenderFullscreenModalDialog(),
+      maybeRenderFullscreenModalDialog(this.preferredApp),
       showStatusBarFlag.get() && renderStatusBar(this.trace),
       this.preferredApp.perfDebugging.renderPerfStats(),
     ]);
@@ -442,7 +442,7 @@ export class UiMainPerTrace implements m.ClassComponent<UiMainPerTraceAttrs> {
     }
   }
 
-  private async maybeShowJsonWarning() {
+  private async maybeShowJsonWarning(app: AppImpl | TraceImpl) {
     // Show warning if the trace is in JSON format.
     const isJsonTrace = this.trace?.traceInfo.traceType === 'json';
     const SHOWN_JSON_WARNING_KEY = 'shownJsonWarning';
@@ -462,6 +462,7 @@ export class UiMainPerTrace implements m.ClassComponent<UiMainPerTraceAttrs> {
     window.localStorage.setItem(SHOWN_JSON_WARNING_KEY, 'true');
 
     showModal({
+      owner: app,
       title: 'Warning',
       content: m(
         'div',

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -164,8 +164,10 @@ export class TrackView {
       scrollIntoView = true;
     }
 
+    const modalOwner = this.trace;
     function showTrackMoveErrorModal(msg: string) {
       showModal({
+        owner: modalOwner,
         title: 'Error',
         content: msg,
         buttons: [{text: 'OK'}],
@@ -612,7 +614,7 @@ const TrackPopupMenu = {
       m(
         MenuItem,
         {label: 'Track details', icon: 'info'},
-        renderTrackDetailsMenu(attrs.node, attrs.descriptor),
+        renderTrackDetailsMenu(attrs.trace, attrs.node, attrs.descriptor),
       ),
       m(MenuDivider),
       m(
@@ -691,7 +693,11 @@ function copyToWorkspace(trace: Trace, node: TrackNode, ws?: Workspace) {
   return ws;
 }
 
-function renderTrackDetailsMenu(node: TrackNode, descriptor?: Track) {
+function renderTrackDetailsMenu(
+  trace: Trace,
+  node: TrackNode,
+  descriptor?: Track,
+) {
   const fullPath = node.fullPath.join(' \u2023 ');
   const query = descriptor?.renderer.getDataset?.()?.query();
 
@@ -729,6 +735,7 @@ function renderTrackDetailsMenu(node: TrackNode, descriptor?: Track) {
             {
               onclick: () => {
                 showModal({
+                  owner: trace,
                   title: 'Query for track',
                   content: () => m(CodeSnippet, {text: query, language: 'SQL'}),
                 });

--- a/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
+++ b/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
@@ -90,16 +90,18 @@ function getFirstUtidOfSelectionOrVisibleWindow(trace: Trace): number {
   return 0;
 }
 
-function showModalErrorAreaSelectionRequired() {
+function showModalErrorAreaSelectionRequired(trace: Trace) {
   showModal({
+    owner: trace,
     title: 'Error: range selection required',
     content:
       'This command requires an area selection over a thread state track.',
   });
 }
 
-function showModalErrorThreadStateRequired() {
+function showModalErrorThreadStateRequired(trace: Trace) {
   showModal({
+    owner: trace,
     title: 'Error: thread state selection required',
     content: 'This command requires a thread state slice to be selected.',
   });
@@ -165,7 +167,7 @@ export default class implements PerfettoPlugin {
       callback: async (utid?: Utid) => {
         const thdInfo = await getThreadInfoForUtidOrSelection(ctx, utid);
         if (thdInfo === undefined) {
-          return showModalErrorThreadStateRequired();
+          return showModalErrorThreadStateRequired(ctx);
         }
         ctx.engine
           .query(`INCLUDE PERFETTO MODULE sched.thread_executing_span;`)
@@ -207,7 +209,7 @@ export default class implements PerfettoPlugin {
       callback: async (utid?: Utid) => {
         const thdInfo = await getThreadInfoForUtidOrSelection(ctx, utid);
         if (thdInfo === undefined) {
-          return showModalErrorThreadStateRequired();
+          return showModalErrorThreadStateRequired(ctx);
         }
         ctx.engine
           .query(
@@ -243,7 +245,7 @@ export default class implements PerfettoPlugin {
         const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
         const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);
         if (trackUtid === 0) {
-          return showModalErrorAreaSelectionRequired();
+          return showModalErrorAreaSelectionRequired(ctx);
         }
         await ctx.engine.query(
           `INCLUDE PERFETTO MODULE sched.thread_executing_span;`,
@@ -286,7 +288,7 @@ export default class implements PerfettoPlugin {
         const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
         const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);
         if (trackUtid === 0) {
-          return showModalErrorAreaSelectionRequired();
+          return showModalErrorAreaSelectionRequired(ctx);
         }
         await ctx.engine.query(
           `INCLUDE PERFETTO MODULE sched.thread_executing_span_with_slice;`,
@@ -321,7 +323,7 @@ export default class implements PerfettoPlugin {
         const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
         const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);
         if (trackUtid === 0) {
-          return showModalErrorAreaSelectionRequired();
+          return showModalErrorAreaSelectionRequired(ctx);
         }
         addQueryResultsTab(ctx, {
           query: `

--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -70,7 +70,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       return;
     }
 
-    const selection = await modalForTableSelection(sqlModules);
+    const selection = await modalForTableSelection(trace, sqlModules);
 
     if (selection) {
       const newNode = new TableSourceNode({

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
@@ -55,12 +55,14 @@ interface TableSelectionResult {
 }
 
 export function modalForTableSelection(
+  trace: Trace,
   sqlModules: SqlModules,
 ): Promise<TableSelectionResult | undefined> {
   return new Promise((resolve) => {
     let searchQuery = '';
 
     showModal({
+      owner: trace,
       title: 'Choose a table',
       content: () => {
         return m(
@@ -77,12 +79,12 @@ export function modalForTableSelection(
                 columnInfoFromSqlColumn(c, true),
               );
               resolve({sqlTable, sourceCols});
-              closeModal();
+              closeModal(undefined, trace);
             },
             searchQuery,
             onSearchQueryChange: (query) => {
               searchQuery = query;
-              redrawModal();
+              redrawModal(trace);
             },
             autofocus: true,
           }),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler.ts
@@ -34,6 +34,7 @@ export function showImportWithStatementModal(
 ) {
   let sqlText = '';
   showModal({
+    owner: trace,
     title: 'Import from WITH statement',
     content: m(
       'div',
@@ -58,13 +59,13 @@ export function showImportWithStatementModal(
           const json = createGraphFromSql(sqlText);
           const newState = deserializeState(json, trace, sqlModules);
           onStateUpdate(newState);
-          closeModal();
+          closeModal(undefined, trace);
         },
       },
       {
         text: 'Cancel',
         action: () => {
-          closeModal();
+          closeModal(undefined, trace);
         },
       },
     ],

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -158,6 +158,7 @@ export class HeapProfileFlamegraphDetailsPanel
       return undefined;
     }
     return m(Modal, {
+      owner: trace,
       title: 'The flamegraph is incomplete',
       vAlign: 'TOP',
       content: m(
@@ -482,6 +483,7 @@ async function downloadPprof(trace: Trace, upid: number, ts: time) {
   );
   if (!trace.traceInfo.downloadable) {
     showModal({
+      owner: trace,
       title: 'Download not supported',
       content: m('div', 'This trace file does not support downloads'),
     });

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
@@ -57,7 +57,10 @@ export class RecordPageV2 implements m.ClassComponent<RecordPageAttrs> {
   constructor({attrs}: m.CVnode<RecordPageAttrs>) {
     this.recMgr = attrs.getRecordingManager();
     if (attrs.subpage && attrs.subpage.startsWith('/' + SHARE_SUBPAGE)) {
-      this.loadShared(attrs.subpage.substring(SHARE_SUBPAGE.length + 2));
+      this.loadShared(
+        attrs.app,
+        attrs.subpage.substring(SHARE_SUBPAGE.length + 2),
+      );
     }
   }
 
@@ -210,13 +213,13 @@ export class RecordPageV2 implements m.ClassComponent<RecordPageAttrs> {
     );
   }
 
-  private async loadShared(hash: string) {
+  private async loadShared(app: App, hash: string) {
     const url = `https://storage.googleapis.com/${BUCKET_NAME}/${hash}`;
     const fetchData = await fetch(url);
     const json = await fetchData.text();
     const res = this.recMgr.restoreSessionFromJson(json);
     if (!res.ok) {
-      showModal({title: 'Restore error', content: res.error});
+      showModal({owner: app, title: 'Restore error', content: res.error});
       return;
     }
     this.recMgr.app.navigate('#!/record/cmdline');

--- a/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
+++ b/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
@@ -70,7 +70,7 @@ export default class implements PerfettoPlugin {
     ctx.commands.registerCommand({
       id: `dev.perfetto.EnableTimelineSync`,
       name: 'Enable timeline sync with other Perfetto UI tabs',
-      callback: () => this.showTimelineSyncDialog(),
+      callback: () => this.showTimelineSyncDialog(ctx),
     });
     ctx.commands.registerCommand({
       id: `dev.perfetto.DisableTimelineSync`,
@@ -80,7 +80,7 @@ export default class implements PerfettoPlugin {
     ctx.commands.registerCommand({
       id: `dev.perfetto.ToggleTimelineSync`,
       name: 'Toggle timeline sync with other PerfettoUI tabs',
-      callback: () => this.toggleTimelineSync(),
+      callback: () => this.toggleTimelineSync(ctx),
       defaultHotkey: 'Mod+Alt+S',
     });
 
@@ -92,7 +92,7 @@ export default class implements PerfettoPlugin {
           intent: this.active ? Intent.Success : Intent.None,
           onclick: this.active
             ? undefined
-            : () => this.showTimelineSyncDialog(),
+            : () => this.showTimelineSyncDialog(ctx),
         };
       },
       popupContent: () => {
@@ -157,15 +157,15 @@ export default class implements PerfettoPlugin {
     } as SyncMessage);
   }
 
-  private toggleTimelineSync() {
+  private toggleTimelineSync(trace: Trace) {
     if (this._sessionId === 0) {
-      this.showTimelineSyncDialog();
+      this.showTimelineSyncDialog(trace);
     } else {
       this.disableTimelineSync(this._sessionId);
     }
   }
 
-  private showTimelineSyncDialog() {
+  private showTimelineSyncDialog(trace: Trace) {
     let clientsSelect: HTMLSelectElement;
 
     // This nested function is invoked when the modal dialog buton is pressed.
@@ -236,6 +236,7 @@ export default class implements PerfettoPlugin {
     };
 
     showModal({
+      owner: trace,
       title: 'Synchronize timeline across several tabs',
       content: renderModalContents,
       buttons: [
@@ -318,7 +319,7 @@ export default class implements PerfettoPlugin {
             lastHeartbeat: Date.now(),
           });
           this.purgeInactiveClients();
-          redrawModal();
+          redrawModal(this._ctx);
         }
         break;
       case 'MSG_SESSION_START':

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -1475,6 +1475,7 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
             label: 'Show Modal',
             onclick: () => {
               showModal({
+                owner: attrs.app,
                 title: 'Attention',
                 icon: Icons.Help,
                 content: () => [


### PR DESCRIPTION
Where applicable, tie the modal dialog state to a trace. Where an explicit trace context is available, inject it into the dialog state. Otherwise, infer it from the currently active trace if there is one, otherwise the app instance.

For android-graphics/sokatoa#4112
