### PR TITLE
fix: crash in postMessageHandler on message without source

### DIFF
--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -155,7 +155,9 @@ export function postMessageHandler(messageEvent: MessageEvent) {
   // * A is navigated to Perfetto UI
   // * B sends the traceBuffer to A
   // * closes itself
-  const fromOpenee = (messageEvent.source as WindowProxy).opener === window;
+  const fromOpenee =
+    messageEvent.source !== null &&
+    (messageEvent.source as WindowProxy).opener === window;
 
   if (
     messageEvent.source === null ||

--- a/ui/src/frontend/post_message_handler_unittest.ts
+++ b/ui/src/frontend/post_message_handler_unittest.ts
@@ -12,9 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {isTrustedOrigin} from './post_message_handler';
+import {isTrustedOrigin, postMessageHandler} from './post_message_handler';
 
 describe('postMessageHandler', () => {
+  test('ignores messages whose source is null without throwing', () => {
+    // A message whose source is null (e.g. posted by a browser extension or
+    // some internal browser machinery) must be gracefully ignored, not crash.
+    const messageEvent = new MessageEvent('message', {
+      data: {some: 'payload'},
+      origin: 'https://html5zombo.com',
+      source: null,
+    });
+    expect(() => postMessageHandler(messageEvent)).not.toThrow();
+  });
+
   test('baked-in trusted origins are trusted', () => {
     expect(isTrustedOrigin('https://chrometto.googleplex.com')).toBeTruthy();
     expect(isTrustedOrigin('https://uma.googleplex.com')).toBeTruthy();


### PR DESCRIPTION
Gracefully handle the case where the incoming message source is null.

For android-graphics/sokatoa#4882
